### PR TITLE
Added support for Xcode Swift toolchains and custom Kernel names

### DIFF
--- a/register.py
+++ b/register.py
@@ -28,18 +28,19 @@ def main():
     args = parse_args()
 
     if args.swift_toolchain is not None:
-        # Use a prebuilt swift toolchain.
+        # Use a prebuilt Swift toolchain.
         if platform.system() == 'Linux':
             lldb_python = '%s/usr/lib/python2.7/site-packages' % args.swift_toolchain
             swift_libs = '%s/usr/lib/swift/linux' % args.swift_toolchain
             repl_swift = '%s/usr/bin/repl_swift' % args.swift_toolchain
         elif platform.system() == 'Darwin':
-            lldb_python = '%s/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/Python' % args.swift_toolchain
+            lldb_python = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/Python' % args.swift_toolchain
             swift_libs = '%s/usr/lib/swift/macosx' % args.swift_toolchain
             repl_swift = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/repl_swift' % args.swift_toolchain
         else:
             raise Exception('Unknown system %s' % platform.system())
-    else:
+
+    elif args.swift_build is not None:
         # Use a build dir created by build-script.
 
         # TODO: Make this work on macos
@@ -52,6 +53,19 @@ def main():
         lldb_python = '%s/lib/python2.7/site-packages' % lldb_build_dir
         swift_libs = '%s/lib/swift/linux' % swift_build_dir
         repl_swift = '%s/bin/repl_swift' % lldb_build_dir
+
+    elif args.xcode_path is not None:
+        # Use an Xcode provided Swift toolchain.
+
+        if platform.system() != 'Darwin':
+            raise Exception('Xcode support is only available on Darwin')
+
+        lldb_framework = '%s/Contents/SharedFrameworks/LLDB.framework' % args.xcode_path
+        xcode_toolchain = '%s/Contents/Developer/Toolchains/XcodeDefault.xctoolchain' % args.xcode_path
+
+        lldb_python = '%s/Resources/Python' % lldb_framework
+        repl_swift = '%s/Resources/repl_swift' % lldb_framework
+        swift_libs = '%s/usr/lib/swift/macosx' % xcode_toolchain
 
     if not os.path.isdir(lldb_python):
         raise Exception('lldb python libs not found at %s' % lldb_python)
@@ -68,7 +82,7 @@ def main():
                 '-f',
                 '{connection_file}',
         ],
-        'display_name': 'Swift',
+        'display_name': args.kernel_name,
         'language': 'swift',
         'env': {
             'PYTHONPATH': lldb_python,
@@ -78,19 +92,29 @@ def main():
     }
     print('kernel.json is\n%s' % json.dumps(kernel_json, indent=2))
 
+    kernel_code_name_allowed_chars = "-."
+    kernel_code_name = filter(lambda x: x.isalnum() or x in kernel_code_name_allowed_chars,
+                              args.kernel_name.lower().replace(" ", kernel_code_name_allowed_chars[0]))
+
     with TemporaryDirectory() as td:
         os.chmod(td, 0o755)
         with open(os.path.join(td, 'kernel.json'), 'w') as f:
             json.dump(kernel_json, f, indent=2)
         KernelSpecManager().install_kernel_spec(
-            td, 'swift', user=args.user, prefix=args.prefix, replace=True)
+            td, kernel_code_name, user=args.user, prefix=args.prefix, replace=True)
 
-    print('Registered kernel!')
+    print('Registered kernel \'{}\' as \'{}\'!'.format(args.kernel_name, kernel_code_name))
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
             description='Register KernelSpec for Swift Kernel')
+            
+    parser.add_argument(
+        '--kernel-name',
+        help='Kernel display name',
+        default='Swift'
+    )
 
     prefix_locations = parser.add_mutually_exclusive_group()
     prefix_locations.add_argument(
@@ -114,6 +138,9 @@ def parse_args():
     swift_locations.add_argument(
         '--swift-build',
         help='Path to build-script build directory, containing swift and lldb')
+    swift_locations.add_argument(
+        '--xcode-path',
+        help='Path to Xcode app bundle')
 
     args = parser.parse_args()
     if args.sys_prefix:
@@ -122,6 +149,8 @@ def parse_args():
         args.swift_toolchain = os.path.realpath(args.swift_toolchain)
     if args.swift_build is not None:
         args.swift_build = os.path.realpath(args.swift_build)
+    if args.xcode_path is not None:
+        args.xcode_path = os.path.realpath(args.xcode_path)
     return args
 
 


### PR DESCRIPTION
This allows to add multiple Swift toolchains to Jupyter:

$ register.py --swift-toolchain /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2018-06-29-a.xctoolchain --kernel-name "Swift for TensorFlow" --user
$ register.py --xcode-path /Applications/Xcode\ Beta.app/ --user --kernel-name "Swift (Xcode Beta)"
$ register.py --xcode-path /Applications/Xcode.app/ --user