### PR TITLE
add sourcekitten integration for code completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ pip2 install jupyter # Must use python2, because LLDB doesn't support python3.
 
 Install a Swift toolchain ([see instructions here](https://github.com/tensorflow/swift/blob/master/Installation.md)).
 
+Optionally [install SourceKitten](https://github.com/jpsim/SourceKitten) (this enables code completion).
+
 Register the kernel with jupyter.
 ```
-python2 register.py --sys-prefix --swift-toolchain <path to swift toolchain>
+python2 register.py --sys-prefix --swift-toolchain <path to swift toolchain> --sourcekitten <path to sourcekitten binary>
 ```
+(omit the `--sourcekitten <path to sourcekitten binary>` if you did not install SourceKitten.)
 
 Now run `jupyter notebook`, and it should have a Swift kernel.


### PR DESCRIPTION
This calls SourceKitten to do code completion. It's a quick and dirty solution that gives us some baseline functionality to play with.

It's not the solution that I want in the long term, because it has some (insurmountable?) problems:
* I have to hackily create a file with all the execution history so that SourceKit can see all the decls that the user has made. This causes at least one bug, as documented in the code comments.
* SourceKit doesn't seem to support completing names that you have already partially typed in.
* Overall, SourceKit seems not intended for doing completions in interactive REPL sessions.

In the long term, I want to use the Swift REPL completion implementation. It doesn't suffer from any of those problems. But it's not exposed through an API, so that will take longer.

Code completion for TensorFlow objects works on Linux but not Mac. Maybe there's a simple fix for that? I'll file a JIRA for it.