### PR TITLE
speed up jupyter display

### DIFF
--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -34,14 +34,12 @@ enum IPythonDisplay {
 }
 
 extension IPythonDisplay {
-  private static func bytes(_ py: PythonObject) -> [CChar] {
-    // faster not-yet-introduced method
-    // return py.swiftBytes!
-
-    // slow placeholder implementation
-    return py.map { el in
-      return CChar(bitPattern: UInt8(Python.ord(el))!)
-    }
+  private static func bytes(_ py: PythonObject)
+      -> KernelCommunicator.BytesReference {
+    // TODO: Replace with a faster implementation that reads bytes directly
+    // from the python object's memory.
+    let bytes = py.map { CChar(bitPattern: UInt8(Python.ord($0))!) }
+    return KernelCommunicator.BytesReference(bytes)
   }
 
   private static func updateParentMessage(

--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -34,22 +34,19 @@ enum IPythonDisplay {
 }
 
 extension IPythonDisplay {
-  private static func bytes(_ py: PythonObject)
-      -> KernelCommunicator.BytesReference {
+  private static func bytes(_ py: PythonObject) -> KernelCommunicator.BytesReference {
     // TODO: Replace with a faster implementation that reads bytes directly
     // from the python object's memory.
-    let bytes = py.map { CChar(bitPattern: UInt8(Python.ord($0))!) }
+    let bytes = py.lazy.map { CChar(bitPattern: UInt8(Python.ord($0))!) }
     return KernelCommunicator.BytesReference(bytes)
   }
 
-  private static func updateParentMessage(
-      to parentMessage: KernelCommunicator.ParentMessage) {
+  private static func updateParentMessage( to parentMessage: KernelCommunicator.ParentMessage) {
     let json = Python.import("json")
     IPythonDisplay.shell.set_parent(json.loads(parentMessage.json))
   }
 
-  private static func consumeDisplayMessages()
-      -> [KernelCommunicator.JupyterDisplayMessage] {
+  private static func consumeDisplayMessages() -> [KernelCommunicator.JupyterDisplayMessage] {
     let displayMessages = IPythonDisplay.socket.messages.map {
       KernelCommunicator.JupyterDisplayMessage(parts: $0.map { bytes($0) })
     }
@@ -72,8 +69,7 @@ extension IPythonDisplay {
     IPythonDisplay.shell = socketAndShell[1]
 
     JupyterKernel.communicator.handleParentMessage(updateParentMessage)
-    JupyterKernel.communicator.afterSuccessfulExecution(
-      run: consumeDisplayMessages)
+    JupyterKernel.communicator.afterSuccessfulExecution(run: consumeDisplayMessages)
   }
 }
 

--- a/KernelCommunicator.swift
+++ b/KernelCommunicator.swift
@@ -42,8 +42,7 @@ public struct KernelCommunicator {
   }
 
   /// Register a handler to run when the parent message changes.
-  public mutating func handleParentMessage(
-      _ handler: @escaping (ParentMessage) -> ()) {
+  public mutating func handleParentMessage(_ handler: @escaping (ParentMessage) -> ()) {
     parentMessageHandlers.append(handler)
   }
 
@@ -51,8 +50,7 @@ public struct KernelCommunicator {
   /// Returns an array of messages, where each message is returned as an array
   /// of parts, where each part is returned as an `UnsafeBufferPointer<CChar>`
   /// to the memory containing the part's bytes.
-  public mutating func triggerAfterSuccessfulExecution()
-      -> [[UnsafeBufferPointer<CChar>]] {
+  public mutating func triggerAfterSuccessfulExecution() -> [[UnsafeBufferPointer<CChar>]] {
     // Keep a reference to the messages, so that their `.unsafeBufferPointer`
     // stays valid while the kernel is reading from them.
     previousDisplayMessages = afterSuccessfulExecutionHandlers.flatMap { $0() }
@@ -60,8 +58,7 @@ public struct KernelCommunicator {
   }
 
   /// The kernel calls this when the parent message changes.
-  public mutating func updateParentMessage(
-      to parentMessage: ParentMessage) {
+  public mutating func updateParentMessage(to parentMessage: ParentMessage) {
     for parentMessageHandler in parentMessageHandlers {
       parentMessageHandler(parentMessage)
     }

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -393,8 +393,7 @@ class SwiftKernel(Kernel):
         }
 
     def _read_display_message(self, sbvalue):
-        parts_sbvalue = sbvalue.GetChildMemberWithName('parts')
-        return [self._read_byte_array(part) for part in parts_sbvalue]
+        return [self._read_byte_array(part) for part in sbvalue]
 
     def _read_byte_array(self, sbvalue):
         get_position_error = lldb.SBError()

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -217,6 +217,7 @@ class SwiftKernel(Kernel):
         self._init_repl_process()
         self._init_completer()
         self._init_kernel_communicator()
+        self._init_int_bitwidth()
 
     def _init_repl_process(self):
         self.debugger = lldb.SBDebugger.Create()
@@ -287,6 +288,12 @@ class SwiftKernel(Kernel):
         result = self._preprocess_and_execute(decl_code)
         if isinstance(result, ExecutionResultError):
             self.log.error(result.description_and_stdout())
+
+    def _init_int_bitwidth(self):
+        result = self._execute('Int.bitWidth')
+        if isinstance(result, ExecutionResultError):
+            self.log.error(result.description_and_stdout())
+        self._int_bitwidth = int(result.result.description)
 
     def _preprocess_and_execute(self, code):
         try:
@@ -390,9 +397,34 @@ class SwiftKernel(Kernel):
         return [self._read_byte_array(part) for part in parts_sbvalue]
 
     def _read_byte_array(self, sbvalue):
-        # TODO: Iterating over the bytes in Python is very slow.
-        return bytes(bytearray(
-                [byte_sbvalue.data.uint8[0] for byte_sbvalue in sbvalue]))
+        get_position_error = lldb.SBError()
+        position = sbvalue \
+                .GetChildMemberWithName('_position') \
+                .GetData() \
+                .GetAddress(get_position_error, 0)
+        if get_position_error.Fail():
+            raise Exception('getting position: %s' % str(get_position_error))
+
+        get_count_error = lldb.SBError()
+        count_data = sbvalue \
+                .GetChildMemberWithName('count') \
+                .GetData()
+        if self._int_bitwidth == 32:
+            count = count_data.GetSignedInt32(get_count_error, 0)
+        elif self._int_bitwidth == 64:
+            count = count_data.GetSignedInt64(get_count_error, 0)
+        else:
+            raise Exception('Unsupported integer bitwidth %d' %
+                            self._int_bitwidth)
+        if get_count_error.Fail():
+            raise Exception('getting count: %s' % str(get_count_error))
+
+        get_data_error = lldb.SBError()
+        data = self.process.ReadMemory(position, count, get_data_error)
+        if get_data_error.Fail():
+            raise Exception('getting data: %s' % str(get_data_error))
+
+        return data
 
     def _send_jupyter_messages(self, messages):
         for display_message in messages['display_messages']:


### PR DESCRIPTION
This removes the most egregious bit of slowness, which speeds up the readme's matplotlib example on my computer from ~4sec to ~0.5sec.

There's still a lot of slowness and redundant copies, but this seems good enough for now so I will stop optimizing. For comparison, the same thing in a plain python notebook takes ~0.3sec.