### PR TITLE
Updated README and fixed Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This kernel is implemented using LLDB's Python APIs.
 # Installation Instructions
 
 Create a virtualenv and install jupyter in it.
+
 ```
 virtualenv venv
 . venv/bin/activate
@@ -26,18 +27,18 @@ Get a Swift toolchain. Here are a few options:
   and then build a toolchain using
   - `SWIFT_PACKAGE=tensorflow_linux,no_test ./swift/utils/build-toolchain local.swift` or
   - `SWIFT_PACKAGE=tensorflow_osx,no_test ./swift/utils/build-toolchain local.swift`.
-* Use an XCode Swift toolchain.
+* Use an Xcode Swift toolchain.
 
 Register the kernel with jupyter. The command depends on which toolchain you got:
 ```
 # If you downloaded a prebuilt toolchain:
-python2 register.py --sys-prefix --swift-toolchain <path to extracted swift toolchain directory>
+python register.py --sys-prefix --swift-toolchain <path to extracted swift toolchain directory>
 
 # If you built a toolchain from sources:
-python2 register.py --sys-prefix --swift-toolchain <path to "swift-nightly-install" directory>
+python register.py --sys-prefix --swift-toolchain <path to "swift-nightly-install" directory>
 
-# If you are using an XCode toolchain:
-python2 register.py --sys-prefix --xcode-path <path to XCode Swift toolchain>
+# If you are using an Xcode provided toolchain:
+python register.py --sys-prefix --xcode-path <path to the Xcode app bundle>
 ```
 
 Optionally add `--sourcekitten <path to sourcekitten binary>` to the command if you installed

--- a/register.py
+++ b/register.py
@@ -23,6 +23,19 @@ import sys
 from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
+kernel_code_name_allowed_chars = "-."
+
+
+def get_kernel_code_name(kernel_name):
+    """
+    Returns a valid kernel code name (like `swift-for-tensorflow`)
+    from a kernel display name (like `Swift for TensorFlow`).
+    """
+
+    kernel_code_name = kernel_name.lower().replace(" ", kernel_code_name_allowed_chars[0])
+    kernel_code_name = "".join(list(filter(lambda x: x.isalnum() or x in kernel_code_name_allowed_chars, kernel_code_name)))
+    return kernel_code_name
+
 
 def make_kernel_env(args):
     """Returns environment varialbes that tell the kernel where things are."""
@@ -131,18 +144,17 @@ def main():
         'language': 'swift',
         'env': kernel_env,
     }
-    print('kernel.json is\n%s' % json.dumps(kernel_json, indent=2))
+    
+    print('kernel.json:\n%s\n' % json.dumps(kernel_json, indent=2))
 
-    kernel_code_name_allowed_chars = "-."
-    kernel_code_name = filter(lambda x: x.isalnum() or x in kernel_code_name_allowed_chars,
-                              args.kernel_name.lower().replace(" ", kernel_code_name_allowed_chars[0]))
+    kernel_code_name = get_kernel_code_name(args.kernel_name)
 
     with TemporaryDirectory() as td:
         os.chmod(td, 0o755)
         with open(os.path.join(td, 'kernel.json'), 'w') as f:
             json.dump(kernel_json, f, indent=2)
         KernelSpecManager().install_kernel_spec(
-            td, kernel_code_name, user=args.user, prefix=args.prefix, replace=True)
+            td, kernel_code_name, user=args.user, prefix=args.prefix)
 
     print('Registered kernel \'{}\' as \'{}\'!'.format(args.kernel_name, kernel_code_name))
 


### PR DESCRIPTION
- Updated README to specify that the Xcode path should point to the app bundle.
- Fixed Python 3 support on `register.py` (useful for whenever `lldb` module becomes supported on Python 3).