### PR TITLE
Prefer the Swift kernel class to system defaults.

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -503,4 +503,7 @@ class SwiftKernel(Kernel):
 
 if __name__ == '__main__':
     from ipykernel.kernelapp import IPKernelApp
-    IPKernelApp.launch_instance(kernel_class=SwiftKernel)
+    # We pass the kernel name as a command-line arg, since Jupyter gives those
+    # highest priority (in particular overriding any system-wide config).
+    IPKernelApp.launch_instance(
+        argv=sys.argv + ['--IPKernelApp.kernel_class=__main__.SwiftKernel'])


### PR DESCRIPTION
Previously, any user-specific or site-wide IPython configuration which
provides a default `kernel_class` attribute would override the `SwiftKernel`
class in `swift_kernel.py`, due to the priority order in IPython
configuration.

This commit switches to provide the `SwiftKernel` class as part of `argv`, as
IPython gives command-line args highest priority among configuration options.

PTAL @marcrasi 