### PR TITLE
Add Docker Usage to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,31 @@ toolchain that you want to use. You may have to pass `register.py` different
 arguments depending on the type of toolchain. See `register.py`'s `--help`
 text for more information.
 
+## Using the Docker Container
+
+This repository also includes a dockerfile which can be used to run a Jupiter Notebook instance which includes this Swift kernel. To biuld the container, the following command may be used:
+
+```
+# from inside the directory of this repository
+docker build -f docker/Dockerfile -t swift-jupyter .
+```
+
+The resulting container comes with the latest Swift for TensorFlow toolchain installed, along with Jupyter and the Swift kernel contained in this repository.
+
+This container can now be run with the following command:
+
+```
+docker run -p 8888:8888 --security-opt seccomp:unconfined -v /my/host/notebooks:/notebooks swift-jupyter
+```
+
+The functions of these parameters are:
+
+- `-p 8888:8888` exposes the port on which Jupyter is running to the host.
+
+- `--security-opt seccomp:unconfined` adjusts the security under which this container is run, which is required for the Swift REPL.
+
+- `-v <host path>:/notebooks` bind mounts a host directory as a volume where notebooks created in the container will be stored.  If this command is omitted, any notebooks created using the container will not be persisted when the container is stopped. 
+
 # Usage Instructions
 
 ## Rich output

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ text for more information.
 
 ## Using the Docker Container
 
-This repository also includes a dockerfile which can be used to run a Jupiter Notebook instance which includes this Swift kernel. To biuld the container, the following command may be used:
+This repository also includes a dockerfile which can be used to run a Jupyter Notebook instance which includes this Swift kernel. To build the container, the following command may be used:
 
-```
+```bash
 # from inside the directory of this repository
 docker build -f docker/Dockerfile -t swift-jupyter .
 ```
@@ -75,7 +75,7 @@ The resulting container comes with the latest Swift for TensorFlow toolchain ins
 
 This container can now be run with the following command:
 
-```
+```bash
 docker run -p 8888:8888 --security-opt seccomp:unconfined -v /my/host/notebooks:/notebooks swift-jupyter
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ The resulting container comes with the latest Swift for TensorFlow toolchain ins
 This container can now be run with the following command:
 
 ```bash
-docker run -p 8888:8888 --security-opt seccomp:unconfined -v /my/host/notebooks:/notebooks swift-jupyter
+docker run -p 8888:8888 --cap-add SYS_PTRACE -v /my/host/notebooks:/notebooks swift-jupyter
 ```
 
 The functions of these parameters are:
 
 - `-p 8888:8888` exposes the port on which Jupyter is running to the host.
 
-- `--security-opt seccomp:unconfined` adjusts the security under which this container is run, which is required for the Swift REPL.
+- `--cap-add SYS_PTRACE` adjusts the privileges with which this container is run, which is required for the Swift REPL.
 
 - `-v <host path>:/notebooks` bind mounts a host directory as a volume where notebooks created in the container will be stored.  If this command is omitted, any notebooks created using the container will not be persisted when the container is stopped. 
 


### PR DESCRIPTION
This commit adds instructions for building and running the Swift Jupyter Kernel using the Docker container defined by the Dockerfile in this repo.

The required run parameters for the container weren't completely obvious, and it took some trial and error to figure out what was needed to make the container usable, so this added documentation attempts to fill in those gaps.

The addition of the security option `--security-opt seccomp:unconfined` was taken from this thread: 

https://groups.google.com/a/tensorflow.org/forum/#!msg/swift/ru0g4A29D8c/fcOeFGhIAAAJ

As discussed there, this option allows the container to make system calls on the host, which is less than ideal.  It does fix a fatal error which occurred when the kernel is run inside the container without this setting, but if there is another way to solve this it would probably be preferred.