### PR TITLE
configurable toolchain url in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,9 @@
 #we don't have to duplicate the installation everywhere.
 FROM ubuntu:18.04
 
+# Allows the caller to specify the toolchain to use.
+ARG swift_tf_url=https://storage.googleapis.com/s4tf-kokoro-artifact-testing/prod/tensorflow/swift/toolchain-ubuntu-docker/release-ubuntu-18.04/5/20181117-115249/toolchain-tar/swift-tensorflow-DEVELOPMENT-2018-11-17-a-.tar.gz
+
 # Install Swift deps.
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -29,11 +32,8 @@ RUN pip2 install --upgrade pip
 RUN pip3 install --upgrade pip
 
 # Download and extract S4TF
-# TODO: This should point at a "latest toolchain" link once we have a job
-# that automatically puts a "latest toolchain" somewhere.
 WORKDIR /swift-tensorflow-toolchain
-ENV SWIFT_TF_URL=https://storage.googleapis.com/s4tf-kokoro-artifact-testing/prod/tensorflow/swift/toolchain-ubuntu-docker/release-ubuntu-18.04/5/20181117-115249/toolchain-tar/swift-tensorflow-DEVELOPMENT-2018-11-17-a-.tar.gz
-RUN curl -fSsL $SWIFT_TF_URL -o swift.tar.gz \
+RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
     && mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz


### PR DESCRIPTION
This will allow the CI tools to run tests against specific versions of the toolchain.