### PR TITLE
make kernel work better with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install these Python modules on your system Python (not in a virtualenv) to
 enable rich output from Swift:
 
 ```
-pip2 install ipykernel pandas matplotlib numpy # Must use python2 because Swift doesn't have python3 interop yet.
+pip install ipykernel pandas matplotlib numpy
 ```
 
 Create a virtualenv and install jupyter in it:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libicu-dev \
         libpython-dev \
+        libpython3-dev \
         libncurses5-dev \
 	libxml2
 
@@ -45,11 +46,16 @@ RUN pip2 --no-cache-dir install \
         ipykernel
 
 # Install some python libraries that are useful to call from swift. Since
-# swift can currently only call python2, install them in python2:
+# swift can interoperate with python2 and python3, install them in both.
 RUN pip2 --no-cache-dir install \
         matplotlib \
         numpy \
         pandas
+RUN pip3 --no-cache-dir install \
+        matplotlib \
+        numpy \
+        pandas \
+	ipykernel
 
 # The tests use jupyter_kernel_test, which requires python3. So install that
 # in python3.
@@ -61,7 +67,8 @@ WORKDIR /swift-jupyter
 COPY . .
 
 # Register the kernel with jupyter
-RUN python2 register.py --user --swift-toolchain /swift-tensorflow-toolchain
+RUN python2 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-version 2.7 --kernel-name "Swift (with Python 2.7)"
+RUN python2 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-library /usr/lib/x86_64-linux-gnu/libpython3.6m.so --kernel-name "Swift (with Python 3.6)"
 
 # Run jupyter on startup
 EXPOSE 8888

--- a/register.py
+++ b/register.py
@@ -97,6 +97,11 @@ def make_kernel_env(args):
     if args.sourcekitten is not None:
         kernel_env['SOURCEKITTEN'] = args.sourcekitten
 
+    if args.swift_python_version is not None:
+        kernel_env['SWIFT_PYTHON_VERSION'] = args.swift_python_version
+    if args.swift_python_library is not None:
+        kernel_env['SWIFT_PYTHON_LIBRARY'] = args.swift_python_library
+
     return kernel_env
 
 
@@ -205,6 +210,15 @@ def parse_args():
              'python2. If you omit this, we will use the interpreter ' +
              'that is running register.py.')
 
+    parser.add_argument(
+        '--swift-python-version',
+        help='direct Swift\'s Python interop library to use this version of ' +
+             'Python')
+    parser.add_argument(
+        '--swift-python-library',
+        help='direct Swift\'s Python interop library to use this Python ' +
+             'library')
+
     args = parser.parse_args()
     if args.sys_prefix:
         args.prefix = sys.prefix
@@ -219,6 +233,10 @@ def parse_args():
     if args.python_interpreter is None:
         args.python_interpreter = sys.executable
     args.python_interpreter = os.path.realpath(args.python_interpreter)
+    if args.swift_python_version is not None and \
+            args.swift_python_library is not None:
+        raise Exception('Should not specify --swift-python-version and ' +
+                        '--swift-python-library at the same time.')
     return args
 
 

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -248,9 +248,18 @@ class SwiftKernel(Kernel):
         if not self.main_bp:
             raise Exception('Could not set breakpoint')
 
+        repl_env = []
         script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+        repl_env.append('PYTHONPATH=%s' % script_dir)
+        if 'SWIFT_PYTHON_VERSION' in os.environ:
+            repl_env.append(
+                'PYTHON_VERSION=%s' % os.environ['SWIFT_PYTHON_VERSION'])
+        if 'SWIFT_PYTHON_LIBRARY' in os.environ:
+            repl_env.append(
+                'PYTHON_LIBRARY=%s' % os.environ['SWIFT_PYTHON_LIBRARY'])
+
         self.process = self.target.LaunchSimple(None,
-                                                ['PYTHONPATH=%s' % script_dir],
+                                                repl_env,
                                                 os.getcwd())
         if not self.process:
             raise Exception('Could not launch process')

--- a/test/test.py
+++ b/test/test.py
@@ -1,9 +1,13 @@
 import unittest
 import jupyter_kernel_test
 
-class SwiftKernelTests(jupyter_kernel_test.KernelTests):
-    kernel_name = 'swift'
-
+# This superclass defines tests but does not run them against kernels, so that
+# we can subclass this to run the same tests against different kernels.
+#
+# In particular, the subclasses run against kernels that interop with differnt
+# versions of Python, so that we test that graphics work with different versions
+# of Python.
+class SwiftKernelTests:
     language_name = 'swift'
 
     code_hello_world = 'print("hello, world!")'
@@ -13,6 +17,38 @@ class SwiftKernelTests(jupyter_kernel_test.KernelTests):
     ]
 
     code_generate_error = 'varThatIsntDefined'
+
+    def test_graphics_matplotlib(self):
+        reply, output_msgs = self.execute_helper(code="""
+            %include "EnableIPythonDisplay.swift"
+        """)
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        reply, output_msgs = self.execute_helper(code="""
+            let np = Python.import("numpy")
+            let plt = Python.import("matplotlib.pyplot")
+            IPythonDisplay.shell.enable_matplotlib("inline")
+        """)
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        reply, output_msgs = self.execute_helper(code="""
+            let ys = np.arange(0, 10, 0.01)
+            plt.plot(ys)
+            plt.show()
+        """)
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertIn('image/png', output_msgs[0]['content']['data'])
+
+
+class SwiftKernelTestsPython27(SwiftKernelTests,
+                               jupyter_kernel_test.KernelTests):
+    kernel_name = 'swift-with-python-2.7'
+
+
+class SwiftKernelTestsPython36(SwiftKernelTests,
+                               jupyter_kernel_test.KernelTests):
+    kernel_name = 'swift-with-python-3.6'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* removes some `dlopen` workarounds that no longer seem necessary, and that crash python3 interop
* makes `EnableIPythonDisplay.swift` work with python3's new `bytes` type, while maintaining backwards-compatibility with python2
* updates readme to remove notes that swift interop can't do python3
* adds ability to specify python version and python library for swift interop when registering a swift kernel
* updates the Dockerfile to register one kernel that uses python2 and one kernel that uses python3
* adds a test for inline graphics
* makes tests run against the python2 and python3 kernels

This should resolve https://github.com/tensorflow/swift/issues/94.