### PR TITLE
Added `PythonObject.display()` function to `EnableIPythonDisplay.swift`

### DIFF
--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -73,4 +73,10 @@ extension IPythonDisplay {
   }
 }
 
+extension PythonObject {
+  func display() {
+    Python.import("IPython.display").display(pythonObject)
+  }
+}
+
 IPythonDisplay.enable()


### PR DESCRIPTION
This allows to display `PythonObject`s easily on a notebook:

```swift
let records: PythonObject = [[1, "A"], [2, "K"], [3, "K"]]
let df = pd.DataFrame(records)
df.display()
```