### PR TITLE
forward all environment variables to swift

### DIFF
--- a/register.py
+++ b/register.py
@@ -98,9 +98,9 @@ def make_kernel_env(args):
         kernel_env['SOURCEKITTEN'] = args.sourcekitten
 
     if args.swift_python_version is not None:
-        kernel_env['SWIFT_PYTHON_VERSION'] = args.swift_python_version
+        kernel_env['PYTHON_VERSION'] = args.swift_python_version
     if args.swift_python_library is not None:
-        kernel_env['SWIFT_PYTHON_LIBRARY'] = args.swift_python_library
+        kernel_env['PYTHON_LIBRARY'] = args.swift_python_library
 
     return kernel_env
 

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -251,12 +251,14 @@ class SwiftKernel(Kernel):
         repl_env = []
         script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
         repl_env.append('PYTHONPATH=%s' % script_dir)
-        if 'SWIFT_PYTHON_VERSION' in os.environ:
-            repl_env.append(
-                'PYTHON_VERSION=%s' % os.environ['SWIFT_PYTHON_VERSION'])
-        if 'SWIFT_PYTHON_LIBRARY' in os.environ:
-            repl_env.append(
-                'PYTHON_LIBRARY=%s' % os.environ['SWIFT_PYTHON_LIBRARY'])
+        env_var_blacklist = [
+            'PYTHONPATH',
+            'REPL_SWIFT_PATH'
+        ]
+        for key in os.environ:
+            if key in env_var_blacklist:
+                continue
+            repl_env.append('%s=%s' % (key, os.environ[key]))
 
         self.process = self.target.LaunchSimple(None,
                                                 repl_env,


### PR DESCRIPTION
There are various environment variables that we need to connect to GPUs, TPUs, etc. Forwarding all the variables seems like the right thing to do.