### PR TITLE
fix graphics on colab

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -440,6 +440,11 @@ class SwiftKernel(Kernel):
         if get_count_error.Fail():
             raise Exception('getting count: %s' % str(get_count_error))
 
+        # ReadMemory requires that count is positive, so early-return an empty
+        # byte array when count is 0.
+        if count == 0:
+            return bytes()
+
         get_data_error = lldb.SBError()
         data = self.process.ReadMemory(position, count, get_data_error)
         if get_data_error.Fail():


### PR DESCRIPTION
Colab initializes the kernel with some settings that make one of the message fields be empty, triggering this bug.

I would like to add a test for this in this repo, so that we catch regressions before trying the kernel in colab, but I think that the jupyter_kernel_test package that I am using for tests does not allow you to configure the settings that you launch the testee kernel with. I will investigate adding such a feature in upstream jupyter_kernel_test, and then use it in this repo.