### PR TITLE
Remove --no-cache-dir as this causes pip install to fail in docker.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,17 +41,17 @@ RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
 
 # swift-jupyter runs in python2 because it uses lldb's python libs which only
 # support python2. Therefore, install swift-jupyter's dependencies in python2:
-RUN pip2 --no-cache-dir install \
+RUN pip2 install \
         jupyter \
         ipykernel
 
 # Install some python libraries that are useful to call from swift. Since
 # swift can interoperate with python2 and python3, install them in both.
-RUN pip2 --no-cache-dir install \
+RUN pip2 install \
         matplotlib \
         numpy \
         pandas
-RUN pip3 --no-cache-dir install \
+RUN pip3 install \
         matplotlib \
         numpy \
         pandas \
@@ -59,7 +59,7 @@ RUN pip3 --no-cache-dir install \
 
 # The tests use jupyter_kernel_test, which requires python3. So install that
 # in python3.
-RUN pip3 --no-cache-dir install \
+RUN pip3 install \
         jupyter_kernel_test
 
 # Copy the kernel into the container


### PR DESCRIPTION
Docker builds were failing with the following error: 

```
Exception:                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                            
  File "/usr/local/lib/python2.7/dist-packages/pip/_internal/cli/base_command.py", line 176, in main                                                                
    status = self.run(options, args)                                                                                                                                                                               
  File "/usr/local/lib/python2.7/dist-packages/pip/_internal/commands/install.py", line 346, in run                                                                                                                
    session=session, autobuilding=True                                                                                                                                                                             
  File "/usr/local/lib/python2.7/dist-packages/pip/_internal/wheel.py", line 848, in build                                                                                        
    assert building_is_possible                                                                                                                                
AssertionError    
```

There is a comment at [wheel.py:843](https://github.com/pypa/pip/blob/7696e7e5303b23d233097cf26749bc1e4a5e0645/src/pip/_internal/wheel.py#L843) in the pip source tree that specifically says that "pip install" might fail when --no-cache-dir is set. Just disabling --no-cache-dir for now. There might be a better fix for this problem.
