### PR TITLE
remove underscore functions from completion matches

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -535,7 +535,10 @@ class SwiftKernel(Kernel):
         insertable_matches = []
         for i in range(sbresponse.GetNumMatches()):
             sbmatch = sbresponse.GetMatchAtIndex(i)
-            insertable_matches.append(prefix + sbmatch.GetInsertable())
+            insertable_match = prefix + sbmatch.GetInsertable()
+            if insertable_match.startswith("_"):
+                continue
+            insertable_matches.append(insertable_match)
         return {
             'status': 'ok',
             'matches': insertable_matches,


### PR DESCRIPTION
One of the main reasons that we add `_` to function names is to hide them from the autocomplete menu. So this PR makes them actually be hidden from the autocomplete menu!