### PR TITLE
enable completion by default

### DIFF
--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -159,7 +159,6 @@ class NotebookTestRunner:
         km, kc = start_new_kernel(kernel_name='swift')
         self.km = km
         self.kc = kc
-        self._execute_code("""%enableCompletion""")
 
     # Runs each code cell in order, asking for completions in each cell along
     # the way. Raises an exception if there is an error or crash. Otherwise,


### PR DESCRIPTION
All the autocomplete crashes that I know of are fixed, and the notebook tester tests for autocomplete crashes pretty thoroughly. So I think we're ready to turn on completion by default.

I left a "%disableCompletion" escape hatch in case we encounter some autocomplete crash that makes things unusable.

I added a test, and the test revealed a few problems that I fixed:
* I was returning a slightly incorrect response in the completions-disabled case.
* Need to call `flush_channels` before each test to clear out messages that previous tests created.