### PR TITLE
handle the case when the swift process gets killed

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -22,10 +22,12 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 import threading
 
 from ipykernel.kernelbase import Kernel
 from jupyter_client.jsonutil import squash_dates
+from tornado import ioloop
 
 
 class ExecutionResult:
@@ -92,6 +94,9 @@ class SwiftError(ExecutionResultError):
 class SIGINTHandler(threading.Thread):
     """Interrupts currently-executing code whenever the process receives a
        SIGINT."""
+
+    daemon = True
+
     def __init__(self, kernel):
         super(SIGINTHandler, self).__init__()
         self.kernel = kernel
@@ -107,6 +112,9 @@ class SIGINTHandler(threading.Thread):
 
 class StdoutHandler(threading.Thread):
     """Collects stdout from the Swift process and sends it to the client."""
+
+    daemon = True
+
     def __init__(self, kernel):
         super(StdoutHandler, self).__init__()
         self.kernel = kernel
@@ -490,6 +498,20 @@ class SwiftKernel(Kernel):
                 'user_expressions': {}
             }
         elif isinstance(result, ExecutionResultError):
+            if not self.process.is_alive:
+                error_message = self._make_error_message(['Process killed'])
+                self.send_response(self.iopub_socket, 'error', error_message)
+
+                # Exit the kernel because there is no way to recover from a
+                # killed process. The UI will tell the user that the kernel has
+                # died and the UI will automatically restart the kernel.
+                # We do the exit in a callback so that this execute request can
+                # cleanly finish before the kernel exits.
+                loop = ioloop.IOLoop.current()
+                loop.add_timeout(time.time()+0.1, loop.stop)
+
+                return error_message
+
             if stdout_handler.had_stdout:
                 # When there is stdout, it is a runtime error. Stdout, which we
                 # have already sent to the client, contains the error message

--- a/test/all_test_local.py
+++ b/test/all_test_local.py
@@ -6,7 +6,7 @@ special kernel named 'swift-with-python-2.7'.
 
 import unittest
 
-from tests.kernel_tests import SwiftKernelTests
+from tests.kernel_tests import SwiftKernelTests, ProcessKilledTest
 from tests.simple_notebook_tests import *
 from tests.tutorial_notebook_tests import *
 

--- a/test/fast_test.py
+++ b/test/fast_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from tests.kernel_tests import SwiftKernelTests
+from tests.kernel_tests import SwiftKernelTests, ProcessKilledTest
 from tests.simple_notebook_tests import *
 
 

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -5,6 +5,7 @@ import unittest
 import jupyter_kernel_test
 import time
 
+from jupyter_client.manager import start_new_kernel
 
 # This superclass defines tests but does not run them against kernels, so that
 # we can subclass this to run the same tests against different kernels.
@@ -199,3 +200,27 @@ class SwiftKernelTestsPython27(SwiftKernelTestsBase,
 class SwiftKernelTests(SwiftKernelTestsBase,
                        jupyter_kernel_test.KernelTests):
     kernel_name = 'swift'
+
+
+# Tests that a killed `repl_swift` process is handled correctly. We put this
+# in a separate class that instantiates a separate kernel from all the other
+# tests so that killing `repl_swift` does not interfere with other tests.
+class ProcessKilledTest(unittest.TestCase):
+    def test_process_killed(self):
+        km, kc = start_new_kernel(kernel_name='swift')
+        kc.execute("""
+            import Glibc
+            exit(0)
+        """)
+
+        had_error = False
+        while True:
+            reply = kc.get_iopub_msg(timeout=10)
+            if reply['header']['msg_type'] == 'error':
+                had_error = True
+                self.assertEqual(['Process killed'],
+                                 reply['content']['traceback'])
+            if reply['header']['msg_type'] == 'status' and \
+                    reply['content']['execution_state'] == 'idle':
+                break
+        self.assertTrue(had_error)


### PR DESCRIPTION
Previously, when the swift process gets killed (e.g. by the OOM killer), you get no error message. Then when you try to execute another cell it says "Kernel is in a bad state. Try restarting the kernel."

This PR makes it give you a "Process killed" error message and makes it restart the kernel for you.

I had to add `daemon = True` to the two threads to make the kernel actually restart. Without `daemon = True`, the threads stayed around and kept the process alive so the kernel never restarted. With `daemon = True`, the threads automatically exit when the main thread exits.

This fixes https://bugs.swift.org/browse/TF-255.