### PR TITLE
make package installation happen in separate directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ display.display(pd.DataFrame.from_records([["col 1": 3, "col 2": 5], ["col 1": 8
 
 ## %install directives
 
+**Note: Requires a Swift for TensorFlow toolchain built on or after March 20, 2019.**
+
 `%install` directives let you install SwiftPM packages so that your notebook
 can import them:
 
@@ -167,8 +169,6 @@ The next argument(s) to `%install` are the products that you want to install fro
   all the packages that the notebook needs.
 * Packages that (transitively) depend on C source code are not supported.
 * Downloads and build artifacts are not cached.
-* Some parts of packages get installed in a global directory, so two kernels
-  that are running at the same time can clobber each other's installations.
 
 ## %include directives
 

--- a/parent_kernel.py
+++ b/parent_kernel.py
@@ -18,6 +18,7 @@
 # then launches "swift_kernel.py" as a subprocess.
 
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -40,6 +41,14 @@ swift_import_search_path = os.path.join(package_install_scratchwork_base,
 os.makedirs(swift_import_search_path, exist_ok=True)
 
 # Launch "swift_kernel.py".
-subprocess.run(args,
-               env=dict(os.environ,
-                        SWIFT_IMPORT_SEARCH_PATH=swift_import_search_path))
+process = subprocess.Popen(
+        args, env=dict(os.environ,
+                       SWIFT_IMPORT_SEARCH_PATH=swift_import_search_path))
+
+# Forward SIGINT to the subprocess so that it can handle interrupt requests
+# from Jupyter. 
+def handle_sigint(sig, frame):
+    process.send_signal(signal.SIGINT)
+signal.signal(signal.SIGINT, handle_sigint)
+
+process.wait()

--- a/parent_kernel.py
+++ b/parent_kernel.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Does some intialization that must happen before "swift_kernel.py" runs, and
+# then launches "swift_kernel.py" as a subprocess.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+# The args to launch "swift_kernel.py" are the same as the args we received,
+# except with "parent_kernel.py" replaced with "swift_kernel.py".
+args = [
+    sys.executable,
+    os.path.join(os.path.dirname(sys.argv[0]), 'swift_kernel.py')
+]
+args += sys.argv[1:]
+
+# Construct a temporary directory for package installation scratchwork. This
+# must happen in the parent process because we need to set the
+# SWIFT_IMPORT_SEARCH_PATH environment in the child to tell LLDB where module
+# files go.
+package_install_scratchwork_base = tempfile.mkdtemp()
+swift_import_search_path = os.path.join(package_install_scratchwork_base,
+                                        'modules')
+os.makedirs(swift_import_search_path, exist_ok=True)
+
+# Launch "swift_kernel.py".
+subprocess.run(args,
+               env=dict(os.environ,
+                        SWIFT_IMPORT_SEARCH_PATH=swift_import_search_path))

--- a/register.py
+++ b/register.py
@@ -55,7 +55,6 @@ def make_kernel_env(args):
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/linux' % args.swift_toolchain
             kernel_env['REPL_SWIFT_PATH'] = '%s/usr/bin/repl_swift' % args.swift_toolchain
             kernel_env['SWIFT_BUILD_PATH'] = '%s/usr/bin/swift-build' % args.swift_toolchain
-            kernel_env['SWIFT_MODULE_PATH'] = '%s/usr/lib/swift/linux/x86_64' % args.swift_toolchain
         elif platform.system() == 'Darwin':
             kernel_env['PYTHONPATH'] = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/Python' % args.swift_toolchain
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/macosx' % args.swift_toolchain
@@ -115,10 +114,6 @@ def validate_kernel_env(kernel_env):
             not os.path.isfile(kernel_env['SWIFT_BUILD_PATH']):
         raise Exception('swift-build binary not found at %s' %
                         kernel_env['SWIFT_BUILD_PATH'])
-    if 'SWIFT_MODULE_PATH' in kernel_env and \
-            not os.path.isdir(kernel_env['SWIFT_MODULE_PATH']):
-        raise Exception('swift modules not found at %s' %
-                        kernel_env['SWIFT_MODULE_PATH'])
 
 
 def main():
@@ -130,7 +125,7 @@ def main():
     kernel_json = {
         'argv': [
             sys.executable,
-            '%s/swift_kernel.py' % script_dir,
+            '%s/parent_kernel.py' % script_dir,
             '-f',
             '{connection_file}',
         ],


### PR DESCRIPTION
Now it installs the swiftmodule files in `<tmpdir>/modules`. Previously, it installed the swiftmodule files in a global directory so that installations in separate kernels could clobber each other.