### PR TITLE
make packages with C installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ The next argument(s) to `%install` are the products that you want to install fro
 
 `%install` directives currently have some limitations:
 
-* You must install all your packages in the first cell that you execute.
+* You must install all your packages in the first cell that you execute. (It
+  will refuse to install packages, and print out an error message explaining
+  why, if you try to install packages in later cells.)
 * Downloads and build artifacts are not cached.
 
 ## %include directives

--- a/README.md
+++ b/README.md
@@ -198,10 +198,7 @@ The next argument(s) to `%install` are the products that you want to install fro
 
 `%install` directives currently have some limitations:
 
-* You can only install packages once before you have to restart the kernel.
-  We recommend having one cell at the beginning of your notebook that installs
-  all the packages that the notebook needs.
-* Packages that (transitively) depend on C source code are not supported.
+* You must install all your packages in the first cell that you execute.
 * Downloads and build artifacts are not cached.
 
 ## %include directives

--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -71,7 +71,7 @@ class CompleteCrash(CompleteException):
 
 class NotebookTestRunner:
     def __init__(self, notebook, char_step=1, repeat_times=1,
-                 execute_timeout=15, complete_timeout=5, verbose=True):
+                 execute_timeout=30, complete_timeout=5, verbose=True):
         """
         noteboook - path to a notebook to run the test on
         char_step - number of chars to step per completion request. 0 disables

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -135,6 +135,10 @@ class SwiftKernelTestsBase:
         self.assertIn('main at <Cell %d>:2:13' % call_cell, traceback[3])
 
     def test_interrupt_execution(self):
+        # Execute something to trigger debugger initialization, so that the
+        # next cell executes quickly.
+        self.execute_helper(code='')
+
         msg_id = self.kc.execute(code="""while true {}""")
 
         # Give the kernel some time to actually start execution, because it
@@ -166,6 +170,10 @@ class SwiftKernelTestsBase:
                 break
 
     def test_async_stdout(self):
+        # Execute something to trigger debugger initialization, so that the
+        # next cell executes quickly.
+        self.execute_helper(code='')
+
         # Test that we receive stdout while execution is happening by printing
         # something and then entering an infinite loop.
         msg_id = self.kc.execute(code="""
@@ -251,7 +259,7 @@ class ProcessKilledTest(unittest.TestCase):
 
         had_error = False
         while True:
-            reply = kc.get_iopub_msg(timeout=10)
+            reply = kc.get_iopub_msg(timeout=30)
             if reply['header']['msg_type'] == 'error':
                 had_error = True
                 self.assertEqual(['Process killed'],

--- a/test/tests/notebooks/PackageWithC/Package.swift
+++ b/test/tests/notebooks/PackageWithC/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:4.2
+
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithC",
+    products: [
+        .library(name: "PackageWithC", targets: ["PackageWithC1", "PackageWithC2"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "PackageWithC1",
+            dependencies: []),
+        .target(
+            name: "PackageWithC2",
+            dependencies: []),
+    ]
+)

--- a/test/tests/notebooks/PackageWithC/Sources/PackageWithC1/include/sillyfunction1.h
+++ b/test/tests/notebooks/PackageWithC/Sources/PackageWithC1/include/sillyfunction1.h
@@ -1,0 +1,1 @@
+int sillyfunction1();

--- a/test/tests/notebooks/PackageWithC/Sources/PackageWithC1/sillyfunction1.c
+++ b/test/tests/notebooks/PackageWithC/Sources/PackageWithC1/sillyfunction1.c
@@ -1,0 +1,3 @@
+int sillyfunction1() {
+  return 42;
+}

--- a/test/tests/notebooks/PackageWithC/Sources/PackageWithC2/include/sillyfunction2.h
+++ b/test/tests/notebooks/PackageWithC/Sources/PackageWithC2/include/sillyfunction2.h
@@ -1,0 +1,1 @@
+int sillyfunction2();

--- a/test/tests/notebooks/PackageWithC/Sources/PackageWithC2/sillyfunction2.c
+++ b/test/tests/notebooks/PackageWithC/Sources/PackageWithC2/sillyfunction2.c
@@ -1,0 +1,3 @@
+int sillyfunction2() {
+  return 1337;
+}

--- a/test/tests/notebooks/install_package_with_c.ipynb
+++ b/test/tests/notebooks/install_package_with_c.ipynb
@@ -2,53 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Completion enabled!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%enableCompletion"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello world\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"hello world\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "eek\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"eek\")"
+    "%install '.package(path: \"$cwd/PackageWithC\")' PackageWithC"
    ]
   },
   {
@@ -56,7 +14,28 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import PackageWithC1\n",
+    "import PackageWithC2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sillyfunction1())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sillyfunction2())"
+   ]
   }
  ],
  "metadata": {

--- a/test/tests/simple_notebook_tests.py
+++ b/test/tests/simple_notebook_tests.py
@@ -44,3 +44,11 @@ class SimpleNotebookTests(unittest.TestCase):
         runner.run()
         self.assertIn('Installation complete', runner.stdout[0])
         self.assertIn('42', runner.stdout[2])
+
+    def test_install_package_with_c(self):
+        notebook = os.path.join(NOTEBOOK_DIR, 'install_package_with_c.ipynb')
+        runner = NotebookTestRunner(notebook, char_step=0, verbose=False)
+        runner.run()
+        self.assertIn('Installation complete', runner.stdout[0])
+        self.assertIn('42', runner.stdout[2])
+        self.assertIn('1337', runner.stdout[3])


### PR DESCRIPTION
All I needed to do was to find the module.modulemap files for the packages and put them in the swift import search path.

But there was a complication: The module.modulemap files need to be in place before you start the debugger -- if you put them in place later, it never sees them. I solved this by rearranging the debugger initialization to lazily initialize the debugger the first time that you execute code. So if you do "%install" before you execute any other code, it puts all the module.modulemap files in the right place before starting the debugger, and the debugger sees them!

I don't know if this complication is a fundamental limitation of how LLDB+ClangImporter work, or if there's an easy way to make them see modulemap files that get put in place later. But my solution seems perfectly fine for now.