### PR TITLE
Dockerfile: don't cache s4tf toolchain tar file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,18 +33,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip2 install --upgrade pip
 RUN pip3 install --upgrade pip
 
-# Download and extract S4TF
-WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
-    && mkdir usr \
-    && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
-    && rm swift.tar.gz
-
-# Copy the kernel into the container
-WORKDIR /swift-jupyter
-COPY . .
-
 # Install swift-jupyter's dependencies in python3 because we run the kernel in python3.
+WORKDIR /swift-jupyter
+COPY requirements*.txt ./
 RUN pip3 install -r requirements.txt
 
 # Install some python libraries that are useful to call from swift. Since
@@ -52,7 +43,19 @@ RUN pip3 install -r requirements.txt
 RUN pip2 install -r requirements_py_graphics.txt
 RUN pip3 install -r requirements_py_graphics.txt
 
+# Copy the kernel into the container
+WORKDIR /swift-jupyter
+COPY . .
+
+# Download and extract S4TF
+WORKDIR /swift-tensorflow-toolchain
+ADD $swift_tf_url swift.tar.gz
+RUN mkdir usr \
+    && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
+    && rm swift.tar.gz
+
 # Register the kernel with jupyter
+WORKDIR /swift-jupyter
 RUN python3 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-version 2.7 --kernel-name "Swift (with Python 2.7)" && \
     python3 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-library /usr/lib/x86_64-linux-gnu/libpython3.6m.so --kernel-name "Swift"
 


### PR DESCRIPTION
Current Dockerfile steps:
1. Install / update system packages & pip
2. Download pre-compiled s4tf toolchain using curl & untar it
3. Copy swift-jupyter source code
4. Install dependencies from requirements*.txt
5. Register kernel

This approach has downside in case someone wants to rebuild the container often in order to get the latest version of s4tf toolchain. As the curl command in step 2 is cached by docker build system, it's only possible to re-download s4tf by disabling build cache (docker build --no-cache), which requires to re-do all the steps in Dockerfile; or by supplying different `swift_tf_url` argument value, e.g. by adding a random query param to the url, which is not very convenient and will also force docker build re-do all subsequent steps after step 2.

Suggested change is to re-order steps and to use Dockerfile `ADD` command so that docker build always checks for the latest s4tf toolchain but still caches other steps as much as possible. 
New order:
1. Install / update system packages & pip
2. Copy requirements*.txt and install dependencies from them (doing that before copying all sources allows to cache this step separately, so it's not executed even if code was updated but requirements*.txt were not updated)
3. Copy swift-jupyter source code
4. Download s4tf toolchain using `ADD` command (that checks if the file has changed)
5. Untar s4tf 
6. Register kernel

Suggested change has own downsides that might make it not acceptable depending on the docker image use-cases:
1. `ADD` command fully downloads the file to check if it has changed, unfortunately it's not smart enough yet to consider E-Tag header: https://github.com/moby/moby/issues/15717. Since this download occurs every time you build the image, it might be too annoying in case one needs to build the image much more often than s4tf is updated.
2. Docker image size is increased by the size of s4tf toolchain .tar file; despite file is removed after `ADD` command, it is still stored in layer created by `ADD` command (can be avoided by squashing the image, but `--squash` option is still experimental).
