### PR TITLE
fix package installation in colab

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -430,13 +430,11 @@ class SwiftKernel(Kernel):
         if len(packages) == 0 and len(swiftpm_flags) == 0:
             return
 
-        # Appears to trigger even in the first cell execution.
-        # Commenting out to work around for now.
-        # if hasattr(self, 'debugger'):
-        #     raise PackageInstallException(
-        #             'Install Error: Packages can only be installed during the '
-        #             'first cell execution. Restart the kernel to install '
-        #             'packages.')
+        if hasattr(self, 'debugger'):
+            raise PackageInstallException(
+                    'Install Error: Packages can only be installed during the '
+                    'first cell execution. Restart the kernel to install '
+                    'packages.')
 
         swift_build_path = os.environ.get('SWIFT_BUILD_PATH')
         if swift_build_path is None:
@@ -735,6 +733,16 @@ class SwiftKernel(Kernel):
         except Exception as e:
             self._send_exception_report('_process_installs', e)
             raise e
+
+        # Return early if the code is empty or whitespace, to avoid
+        # initializing Swift and preventing package installs.
+        if len(code) == 0 or code.isspace():
+            return {
+                'status': 'ok',
+                'execution_count': self.execution_count,
+                'payload': [],
+                'user_expressions': {}
+            }
 
         if not hasattr(self, 'debugger'):
             self._init_swift()

--- a/test/all_test_local.py
+++ b/test/all_test_local.py
@@ -6,7 +6,7 @@ special kernel named 'swift-with-python-2.7'.
 
 import unittest
 
-from tests.kernel_tests import SwiftKernelTests, ProcessKilledTest
+from tests.kernel_tests import SwiftKernelTests, OwnKernelTests
 from tests.simple_notebook_tests import *
 from tests.tutorial_notebook_tests import *
 

--- a/test/fast_test.py
+++ b/test/fast_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from tests.kernel_tests import SwiftKernelTests, ProcessKilledTest
+from tests.kernel_tests import SwiftKernelTests, OwnKernelTests
 from tests.simple_notebook_tests import *
 
 


### PR DESCRIPTION
Colab was sending some blank execution requests, which caused the `PackageInstallException` to trigger when you try to install packages. We previously worked around it by commenting out the `PackageInstallException`.

This PR fixes it more properly by ignoring blank execution requests.