### PR TITLE
Allow user to set an install location for modules

### DIFF
--- a/parent_kernel.py
+++ b/parent_kernel.py
@@ -36,9 +36,9 @@ args += sys.argv[1:]
 # SWIFT_IMPORT_SEARCH_PATH environment in the child to tell LLDB where module
 # files go.
 package_install_scratchwork_base = tempfile.mkdtemp()
+package_install_scratchwork_base = os.path.join(package_install_scratchwork_base, 'swift-install')
 swift_import_search_path = os.path.join(package_install_scratchwork_base,
                                         'modules')
-os.makedirs(swift_import_search_path, exist_ok=True)
 
 # Launch "swift_kernel.py".
 process = subprocess.Popen(

--- a/test/tests/notebooks/install_package_with_user_location.ipynb
+++ b/test/tests/notebooks/install_package_with_user_location.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%install-location $cwd/swift-modules\n",
+    "%install '.package(path: \"$cwd/SimplePackage\")' SimplePackage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import SimplePackage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(publicIntThatIsInSimplePackage)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Swift",
+   "language": "swift",
+   "name": "swift"
+  },
+  "language_info": {
+   "file_extension": ".swift",
+   "mimetype": "text/x-swift",
+   "name": "swift",
+   "version": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -14,7 +14,7 @@ class TutorialNotebookTests(unittest.TestCase):
     def setUpClass(cls):
         cls.tmp_dir = tempfile.mkdtemp()
         git_url = 'https://github.com/tensorflow/swift.git'
-        os.system('git clone %s %s' % (git_url, cls.tmp_dir))
+        os.system('git clone %s %s -b nightly-notebooks' % (git_url, cls.tmp_dir))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
The preferred package install location can be set using the `%install-location` magic command, which points to the destination directory for compiled Swift modules. This allows the user to compile and install packages in a notebook (using the `%install` directives), and then import them in a different notebook without recompiling.
                                                                         
The compiled packages are built as dependencies of a `jupyterInstalledPackages` target. Note that compilation generates a dylib that must be `dlopen`ed before pre-built packages can be imported. For this reason, the `.so` file is also copied inside the module install location, and loaded when the Swift process is started.                                                

A lock is taken while building and installing modules, to prevent conflicts between notebooks running simultaneously.
                                                             
Limitations:                                                             
- Build artifacts are not cached. When restarting a notebook, comment or skip installation directives (but keep `%install-location`) to prevent the recompilation of packages previously built.
- `jupyterInstalledPackages.so` must depend on the modules that are going to be later used, possibly in a different notebook. This means that all packages should be built in the same notebook session.
