### PR TITLE
use nightly-notebooks for test

### DIFF
--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -14,7 +14,7 @@ class TutorialNotebookTests(unittest.TestCase):
     def setUpClass(cls):
         cls.tmp_dir = tempfile.mkdtemp()
         git_url = 'https://github.com/tensorflow/swift.git'
-        os.system('git clone %s %s' % (git_url, cls.tmp_dir))
+        os.system('git clone %s %s -b nightly-notebooks' % (git_url, cls.tmp_dir))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
So that we can update the notebooks to account for backwards-incompatible changes in APIs, without breaking the notebooks in `master` for users on older toolchains (e.g. users using colab).