### PR TITLE
Fix %install issues with modulemaps

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -42,6 +42,3 @@ traitlets==4.3.2
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.4.2
-
-# TODO: Remove after removing the dependency on sqlite.
-pysqlite

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -42,3 +42,6 @@ traitlets==4.3.2
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.4.2
+
+# TODO: Remove after removing the dependency on sqlite.
+pysqlite

--- a/register.py
+++ b/register.py
@@ -56,6 +56,7 @@ def make_kernel_env(args):
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/linux' % args.swift_toolchain
             kernel_env['REPL_SWIFT_PATH'] = '%s/usr/bin/repl_swift' % args.swift_toolchain
             kernel_env['SWIFT_BUILD_PATH'] = '%s/usr/bin/swift-build' % args.swift_toolchain
+            kernel_env['SWIFT_PACKAGE_PATH'] = '%s/usr/bin/swift-package' % args.swift_toolchain
         elif platform.system() == 'Darwin':
             kernel_env['PYTHONPATH'] = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/Python' % args.swift_toolchain
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/macosx' % args.swift_toolchain
@@ -118,6 +119,10 @@ def validate_kernel_env(kernel_env):
             not os.path.isfile(kernel_env['SWIFT_BUILD_PATH']):
         raise Exception('swift-build binary not found at %s' %
                         kernel_env['SWIFT_BUILD_PATH'])
+    if 'SWIFT_PACKAGE_PATH' in kernel_env and \
+            not os.path.isfile(kernel_env['SWIFT_PACKAGE_PATH']):
+        raise Exception('swift-package binary not found at %s' %
+                        kernel_env['SWIFT_PACKAGE_PATH'])
     if 'PYTHON_LIBRARY' in kernel_env and \
             not os.path.isfile(kernel_env['PYTHON_LIBRARY']):
         raise Exception('python library not found at %s' %


### PR DESCRIPTION
Following problems were discovered with %install:
1. When package contains a modulemap with relative header paths and modulemap files are copied to a new location under `/tmp/xxx` relative paths become invalid. Package compiles but then cannot be imported. Example of package that had such problem is Vapor.
2. When package with modulemap file is installed from disk, swift doesn't place it in `.build` folder of `jupyterInstalledPackages`, thus the swift kernel code doesn't copy modulemap file at all. Package compiles but cannot be imported. Example of such problem is described [here](https://forums.fast.ai/t/opencv-in-swift/44514/5)

Proposed fixes:
1. Header paths in modulemap are made absolute when copying.
2. List of modulemap files is taken from `.build/build.db` database.

Downsides:
1. It's not clear if `.build/build.db` is valid to use (e.g. it has some quirks like all paths start with "N"). Maybe its format depends on builder version and/or may change in the future.
2. `build.db` contains all dependencies including system ones that mustn't be copied into `jupyterInstalledPackages`. It's not clear how to correctly separate system deps from non-system. Currently they are filtered by path, but this is not robust (e.g. we filter out `/usr/lib`, but the package of interest may in theory be located there).