### PR TITLE
extra include search paths using pkg-config and symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ directive `%install-extra-include-command`, followed by a shell command that
 prints "-I/path/to/extra/include/files". For example,
 
 ```
-// Puts all the headers in /usr/local/include/glib-2.0 on the header search path.
-%install-extra-include-command echo -I/usr/local/include/glib-2.0
+// Puts the headers in /usr/include/glib-2.0 on the header search path.
+%install-extra-include-command echo -I/usr/include/glib-2.0
 
-// Puts all the headers returned by `pkg-config` on the header search path.
+// Puts the headers returned by `pkg-config` on the header search path.
 %install-extra-include-command pkg-config --cflags-only-I glib-2.0
 ```
 


### PR DESCRIPTION
Implements a new feature that you use like this:

```
%install-extra-include-command pkg-config --cflags-only-I vips
```

This feature will run the specified commands, extract the -I flags from them, and create links from the kernel’s “install location” to all the headers.

