### PR TITLE
Prevent bad state kernel after multiple %installs

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -650,13 +650,13 @@ class SwiftKernel(Kernel):
             # Create a separate directory for each modulemap file because the
             # ClangImporter requires that they are all named
             # "module.modulemap".
-            modulemap_dest = os.path.join(swift_import_search_path,
-                                          'modulemap-%d' % index)
-            os.makedirs(modulemap_dest, exist_ok=True)
-            src_folder, src_filename = os.path.split(filename)
-            dst_path = os.path.join(modulemap_dest, src_filename)
+            # Use the module name to prevent two modulema[s for the same
+            # depndency ending up in multiple directories after several
+            # installations, causing the kernel to end up in a bad state.
             # Make all relative header paths in module.modulemap absolute
-            # because we copy file to different location
+            # because we copy file to different location.
+
+            src_folder, src_filename = os.path.split(filename)
             with open(filename, encoding='utf8') as file:
                 modulemap_contents = file.read()
                 modulemap_contents = re.sub(
@@ -665,6 +665,13 @@ class SwiftKernel(Kernel):
                         (m.group(1) if os.path.isabs(m.group(1)) else os.path.abspath(os.path.join(src_folder, m.group(1)))),
                     modulemap_contents
                 )
+
+                module_match = re.match(r'module\s+([^\s]+)\s.*{', modulemap_contents)
+                module_name = module_match.group(1) if module_match is not None else str(index)
+                modulemap_dest = os.path.join(swift_import_search_path, 'modulemap-%s' % module_name)
+                os.makedirs(modulemap_dest, exist_ok=True)
+                dst_path = os.path.join(modulemap_dest, src_filename)
+
                 with open(dst_path, 'w', encoding='utf8') as outfile:
                     outfile.write(modulemap_contents)
 


### PR DESCRIPTION
The name of the package is now used instead of a numeric suffix, so we get
directories like these:
 modulemap-COpenCV/
 modulemap-CSwiftVips/
 modulemap-opencv4/
 modulemap-vips/

Instead of modulemap-0, etc.

The reason for doing this is that the modulemap-<number> directories
sometimes got polluted after installing packages across different
notebooks. This is made worse by the fact that `swift package
show-dependencies` sometimes declares dependencies for packages in the
.build directory that were left out by previous installations, and are
not really in use for the package that is being currently compiled.

After installing multiple packages, we could end up in a situation
where multiple modulemap- directories refer to the same package,
because one dependency was assigned slot '1' in one installation and
'0' in another one. When this happens, the process ended up in a "bad
state" and we had to resort to removing the swift-install folder and
start all over again.

Another alternative would have been to delete all modulemap directories
when installing a new package. But I have something else coming in a
future pull request that will take advantage of reusing all installed
modules.