### PR TITLE
fix display method lookup

### DIFF
--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -75,7 +75,7 @@ extension IPythonDisplay {
 
 extension PythonObject {
   func display() {
-    Python.import("IPython.display").display(pythonObject)
+    Python.import("IPython.display")[dynamicMember: "display"](pythonObject)
   }
 }
 


### PR DESCRIPTION
`.display(pythonObject)` seems to be resolving to some method that takes no arguments. So I changed it to explicitly do the dynamic member lookup.

This fixes some of the swift-jupyter test failures that we're getting on newer toolchains.