### PR TITLE
disable completions by default

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -199,7 +199,10 @@ class SwiftKernel(Kernel):
         # SBTarget.CompleteCode API.
         # The user can disable/enable using "%disableCompletion" and
         # "%enableCompletion".
-        self.completion_enabled = hasattr(self.target, 'CompleteCode')
+        # self.completion_enabled = hasattr(self.target, 'CompleteCode')
+        
+        # TODO(TF-743): Reenable completion by default.
+        self.completion_enabled = false
 
     def _init_repl_process(self):
         self.debugger = lldb.SBDebugger.Create()

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -202,7 +202,7 @@ class SwiftKernel(Kernel):
         # self.completion_enabled = hasattr(self.target, 'CompleteCode')
         
         # TODO(TF-743): Reenable completion by default.
-        self.completion_enabled = false
+        self.completion_enabled = False
 
     def _init_repl_process(self):
         self.debugger = lldb.SBDebugger.Create()

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -203,6 +203,7 @@ class SwiftKernelTestsBase:
             if msg['msg_type'] == 'status':
                 break
 
+    @unittest.skip  # TODO(TF-743): Reenable.
     def test_swift_completion(self):
         reply, output_msgs = self.execute_helper(code="""
             func aFunctionToComplete() {}


### PR DESCRIPTION
Completions are currently very crashy (https://bugs.swift.org/projects/TF/issues/TF-743). Let's disable them until we get the fix from upstream into the S4TF toolchain.