### PR TITLE
Bump prompt-toolkit version to 2.0.9 in requirements.txt

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -27,7 +27,7 @@ pandocfilters==1.4.2
 pexpect==4.6.0
 pickleshare==0.7.5
 prometheus-client==0.5.0
-prompt-toolkit==2.0.0
+prompt-toolkit==2.0.9
 ptyprocess==0.6.0
 Pygments==2.1.3
 python-dateutil==2.5.3

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -27,7 +27,7 @@ pandocfilters==1.4.2
 pexpect==4.6.0
 pickleshare==0.7.5
 prometheus-client==0.5.0
-prompt-toolkit==1.0.15
+prompt-toolkit==2.0.0
 ptyprocess==0.6.0
 Pygments==2.1.3
 python-dateutil==2.5.3


### PR DESCRIPTION
Unblocks toolchain builds which are failing due to version incompatibility: https://g3c.corp.google.com/results/invocations/f53d83dc-58a8-4c74-b6f3-c99f17f23738/targets/s4tf%2Fswift-jupyter%2Fubuntu%2Frelease/log