### PR TITLE
Revert "disable iris notebook test"

### DIFF
--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -239,6 +239,12 @@ class NotebookTestRunner:
         while True:
             self._init_kernel()
             try:
+                # Executing a simple cell and sleeping a bit seems to prevent
+                # the following intermittent assertion failure.
+                #   /swift-base/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:304: void llvm::RuntimeDyldELF::resolveX86_64Relocation(const llvm::SectionEntry &, uint64_t, uint64_t, uint32_t, int64_t, uint64_t): Assertion `isInt<32>(RealOffset)' failed.
+                self._execute_code('print("Hello World")')
+                time.sleep(5)
+
                 for _ in range(self.repeat_times):
                     self._run_notebook_once(failed_completions)
                 break

--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -72,8 +72,7 @@ class CompleteCrash(CompleteException):
 class NotebookTestRunner:
     # TODO(TF-743): Change default char_step back to 1, to reenable completion tests.
     def __init__(self, notebook, char_step=0, repeat_times=1,
-                 execute_timeout=60, complete_timeout=5, verbose=True,
-                 assertion_failure_workaround=False):
+                 execute_timeout=60, complete_timeout=5, verbose=True):
         """
         noteboook - path to a notebook to run the test on
         char_step - number of chars to step per completion request. 0 disables
@@ -89,7 +88,6 @@ class NotebookTestRunner:
         self.execute_timeout = execute_timeout
         self.complete_timeout = complete_timeout
         self.verbose = verbose
-        self.assertion_failure_workaround = assertion_failure_workaround
 
         notebook_dir = os.path.dirname(notebook)
         os.chdir(notebook_dir)
@@ -241,14 +239,6 @@ class NotebookTestRunner:
         while True:
             self._init_kernel()
             try:
-                if self.assertion_failure_workaround:
-                    # Executing a simple cell and sleeping a bit seems to
-                    # prevent the following intermittent assertion failure.
-                    #   /swift-base/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:304: void llvm::RuntimeDyldELF::resolveX86_64Relocation(const llvm::SectionEntry &, uint64_t, uint64_t, uint32_t, int64_t, uint64_t): Assertion `isInt<32>(RealOffset)' failed.
-                    for _ in range(2):
-                        self._execute_code('print("Hello World")')
-                        time.sleep(30)
-
                 for _ in range(self.repeat_times):
                     self._run_notebook_once(failed_completions)
                 break

--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -72,7 +72,7 @@ class CompleteCrash(CompleteException):
 class NotebookTestRunner:
     # TODO(TF-743): Change default char_step back to 1, to reenable completion tests.
     def __init__(self, notebook, char_step=0, repeat_times=1,
-                 execute_timeout=30, complete_timeout=5, verbose=True):
+                 execute_timeout=60, complete_timeout=5, verbose=True):
         """
         noteboook - path to a notebook to run the test on
         char_step - number of chars to step per completion request. 0 disables

--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -72,7 +72,8 @@ class CompleteCrash(CompleteException):
 class NotebookTestRunner:
     # TODO(TF-743): Change default char_step back to 1, to reenable completion tests.
     def __init__(self, notebook, char_step=0, repeat_times=1,
-                 execute_timeout=60, complete_timeout=5, verbose=True):
+                 execute_timeout=60, complete_timeout=5, verbose=True,
+                 assertion_failure_workaround=False):
         """
         noteboook - path to a notebook to run the test on
         char_step - number of chars to step per completion request. 0 disables
@@ -88,6 +89,7 @@ class NotebookTestRunner:
         self.execute_timeout = execute_timeout
         self.complete_timeout = complete_timeout
         self.verbose = verbose
+        self.assertion_failure_workaround = assertion_failure_workaround
 
         notebook_dir = os.path.dirname(notebook)
         os.chdir(notebook_dir)
@@ -239,11 +241,13 @@ class NotebookTestRunner:
         while True:
             self._init_kernel()
             try:
-                # Executing a simple cell and sleeping a bit seems to prevent
-                # the following intermittent assertion failure.
-                #   /swift-base/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:304: void llvm::RuntimeDyldELF::resolveX86_64Relocation(const llvm::SectionEntry &, uint64_t, uint64_t, uint32_t, int64_t, uint64_t): Assertion `isInt<32>(RealOffset)' failed.
-                self._execute_code('print("Hello World")')
-                time.sleep(5)
+                if self.assertion_failure_workaround:
+                    # Executing a simple cell and sleeping a bit seems to
+                    # prevent the following intermittent assertion failure.
+                    #   /swift-base/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:304: void llvm::RuntimeDyldELF::resolveX86_64Relocation(const llvm::SectionEntry &, uint64_t, uint64_t, uint32_t, int64_t, uint64_t): Assertion `isInt<32>(RealOffset)' failed.
+                    for _ in range(2):
+                        self._execute_code('print("Hello World")')
+                        time.sleep(30)
 
                 for _ in range(self.repeat_times):
                     self._run_notebook_once(failed_completions)

--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -23,7 +23,8 @@ class TutorialNotebookTests(unittest.TestCase):
     def test_iris(self):
         notebook = os.path.join(self.tmp_dir, 'docs', 'site', 'tutorials',
                                 'model_training_walkthrough.ipynb')
-        runner = NotebookTestRunner(notebook, verbose=False)
+        runner = NotebookTestRunner(notebook, verbose=False,
+                                    assertion_failure_workaround=True)
         runner.run()
         self.assertEqual([], runner.unexpected_errors)
         all_stdout = '\n\n'.join(runner.stdout)

--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -20,7 +20,6 @@ class TutorialNotebookTests(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(cls.tmp_dir)
 
-    @unittest.skip  # TODO(TF-746): Reenable.
     def test_iris(self):
         notebook = os.path.join(self.tmp_dir, 'docs', 'site', 'tutorials',
                                 'model_training_walkthrough.ipynb')

--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -23,8 +23,7 @@ class TutorialNotebookTests(unittest.TestCase):
     def test_iris(self):
         notebook = os.path.join(self.tmp_dir, 'docs', 'site', 'tutorials',
                                 'model_training_walkthrough.ipynb')
-        runner = NotebookTestRunner(notebook, verbose=False,
-                                    assertion_failure_workaround=True)
+        runner = NotebookTestRunner(notebook, verbose=False)
         runner.run()
         self.assertEqual([], runner.unexpected_errors)
         all_stdout = '\n\n'.join(runner.stdout)


### PR DESCRIPTION
Reverts google/swift-jupyter#72

Also increases a timeout so that we hopefully get fewer timeout related failures.