### PR TITLE
reenable completions and tests

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -199,10 +199,7 @@ class SwiftKernel(Kernel):
         # SBTarget.CompleteCode API.
         # The user can disable/enable using "%disableCompletion" and
         # "%enableCompletion".
-        # self.completion_enabled = hasattr(self.target, 'CompleteCode')
-        
-        # TODO(TF-743): Reenable completion by default.
-        self.completion_enabled = False
+        self.completion_enabled = hasattr(self.target, 'CompleteCode')
 
     def _init_repl_process(self):
         self.debugger = lldb.SBDebugger.Create()

--- a/test/notebook_tester.py
+++ b/test/notebook_tester.py
@@ -70,8 +70,7 @@ class CompleteCrash(CompleteException):
 
 
 class NotebookTestRunner:
-    # TODO(TF-743): Change default char_step back to 1, to reenable completion tests.
-    def __init__(self, notebook, char_step=0, repeat_times=1,
+    def __init__(self, notebook, char_step=1, repeat_times=1,
                  execute_timeout=60, complete_timeout=5, verbose=True):
         """
         noteboook - path to a notebook to run the test on

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -203,7 +203,6 @@ class SwiftKernelTestsBase:
             if msg['msg_type'] == 'status':
                 break
 
-    @unittest.skip  # TODO(TF-743): Reenable.
     def test_swift_completion(self):
         reply, output_msgs = self.execute_helper(code="""
             func aFunctionToComplete() {}


### PR DESCRIPTION
I expect this to fail kokoro because the current toolchain has some completion crashers.

Once we have a toolchain with fixed completions, we can rerun kokoro and this should pass.