### PR TITLE
add ability to clear the whole output area

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -145,7 +145,7 @@ class StdoutHandler(threading.Thread):
     # clearing the whole display with a 'clear_output' message to the jupyter
     # client.
     def _send_stdout(self, stdout):
-        clear_sequence = '\033[3J'
+        clear_sequence = '\033[2J'
         clear_sequence_index = stdout.find(clear_sequence)
         if clear_sequence_index != -1:
             self._send_stdout(stdout[:clear_sequence_index])

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -236,6 +236,40 @@ class SwiftKernelTestsBase:
                          ['aFunctionToComplete()'])
         self.flush_channels()
 
+    def test_swift_clear_output(self):
+        reply, output_msgs = self.execute_helper(code=r"""
+            print("before the clear")
+            print("\u{001B}[3J")
+            print("after the clear")
+        """)
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertEqual(
+            dict((k, output_msgs[0][k]) for k in ['msg_type', 'content']),
+            {
+                'msg_type': 'stream',
+                'content': {
+                    'name': 'stdout',
+                    'text': 'before the clear\r\n',
+                },
+            })
+        self.assertEqual(
+            dict((k, output_msgs[1][k]) for k in ['msg_type', 'content']),
+            {
+                'msg_type': 'clear_output',
+                'content': {
+                    'wait': False
+                }
+            })
+        self.assertEqual(
+            dict((k, output_msgs[2][k]) for k in ['msg_type', 'content']),
+            {
+                'msg_type': 'stream',
+                'content': {
+                    'name': 'stdout',
+                    'text': '\r\nafter the clear\r\n',
+                },
+            })
+
 
 class SwiftKernelTestsPython27(SwiftKernelTestsBase,
                                jupyter_kernel_test.KernelTests):

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -239,7 +239,7 @@ class SwiftKernelTestsBase:
     def test_swift_clear_output(self):
         reply, output_msgs = self.execute_helper(code=r"""
             print("before the clear")
-            print("\u{001B}[3J")
+            print("\u{001B}[2J")
             print("after the clear")
         """)
         self.assertEqual(reply['content']['status'], 'ok')


### PR DESCRIPTION
Makes the "[2J" ANSI escape sequence work to clear the output, by replacing it with a 'clear_output' message to the jupyter client.

I've observed some weirdness where if you use this it'll not print messages that you print right before the cell finishes. So that needs a bit more investigation.

Alternatives considered:
* Send the 'clear_output' message from the Swift process. This is not good because we currently can only send messages from the Swift process when the cell finishes executing, so we wouldn't be able to clear the output while the cell is running. We should switch to this alternative when it is possible to send messages from Swift.
* Let "[2J" get to the client. This doesn't work because the client doesn't handle the "[2J" sequence: https://github.com/jupyter/notebook/issues/4315
* IPython.display.clear_output (https://github.com/ipython/ipython/blob/4a2240fb440c497e9e195d9ff43d96973b7ae33f/IPython/core/display.py#L1418) seems to use the "[2K" sequence, so maybe that's already handled by the client. But this doesn't do anything when I print it from Swift. I don't know why.