### PR TITLE
fix build.db lookup because swiftpm moved it

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -686,8 +686,13 @@ class SwiftKernel(Kernel):
 
         # == Copy .swiftmodule and modulemap files to SWIFT_IMPORT_SEARCH_PATH ==
 
-        build_db_file = os.path.join(package_base_path, '.build', 'build.db')
-        if not os.path.exists(build_db_file):
+        # Search for build.db.
+        build_db_candidates = [
+            os.path.join(bin_dir, '..', 'build.db'),
+            os.path.join(package_base_path, '.build', 'build.db'),
+        ]
+        build_db_file = next(filter(os.path.exists, build_db_candidates), None)
+        if build_db_file is None:
             raise PackageInstallException('build.db is missing')
 
         # Execute swift-package show-dependencies to get all dependencies' paths


### PR DESCRIPTION
In the 2019-11-11 merge, SwiftPM moves `build.db` from `.build` to `.build/x86_64-unknown-linux-gnu`, so we can't find it any more.

This PR looks in the old location (for backwards compatibility) and the new location.