### PR TITLE
Add convenience functions for drawing Swiftplot plots

### DIFF
--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -79,4 +79,22 @@ extension PythonObject {
   }
 }
 
+#if canImport(SwiftPlot)
+import SwiftPlot
+import AGGRenderer
+var __agg_renderer = AGGRenderer()
+extension Plot {
+  func display(size: Size = Size(width: 1000, height: 660)) {
+    drawGraph(size: size, renderer: __agg_renderer)
+    let image_b64 = __agg_renderer.base64Png()
+    
+    let displayImage = Python.import("IPython.display")
+    let codecs = Python.import("codecs")
+    let imageData = codecs.decode(Python.bytes(image_b64, encoding: "utf8"),
+                                  encoding: "base64")
+    displayImage.Image(data: imageData, format: "png").display()
+  }
+}
+#endif
+
 IPythonDisplay.enable()

--- a/EnableJupyterDisplay.swift
+++ b/EnableJupyterDisplay.swift
@@ -177,9 +177,21 @@ extension JupyterDisplay {
     }
 }
 
-JupyterDisplay.enable()
-
 func display(base64EncodedPNG: String) {
     let data = JupyterDisplay.MessageContent(base64EncodedPNG: base64EncodedPNG).json
     JupyterDisplay.messages.append(JupyterDisplay.Message(content: data))
 }
+
+#if canImport(SwiftPlot)
+import SwiftPlot
+import AGGRenderer
+var __agg_renderer = AGGRenderer()
+extension Plot {
+  func display(size: Size = Size(width: 1000, height: 660)) {
+    drawGraph(size: size, renderer: __agg_renderer)
+    display(base64EncodedPNG: __agg_renderer.base64Png())
+  }
+}
+#endif
+
+JupyterDisplay.enable()


### PR DESCRIPTION
This means you can do something like:

```
var lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
lineGraph.addSeries(x, y, label: "Plot 1", color: .lightBlue)
// ...
lineGraph.display()
```

Thanks to @WilliamHYZhang for figuring out Colab support (EnableIPythonDisplay)