### PR TITLE
Allow displaying of messages with custom mimetype data

### DIFF
--- a/EnableJupyterDisplay.swift
+++ b/EnableJupyterDisplay.swift
@@ -123,13 +123,10 @@ enum JupyterDisplay {
         }
     }
 
-    struct MessageContent: Encodable {
+    struct MessageContent<Data>: Encodable where Data: Encodable {
         let metadata = "{}"
         let transient = "{}"
-        let data: PNGImageData
-        init(base64EncodedPNG: String) {
-            data = PNGImageData(base64EncodedPNG: base64EncodedPNG)
-        }
+        let data: Data
         var json: String {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -180,6 +177,7 @@ extension JupyterDisplay {
 JupyterDisplay.enable()
 
 func display(base64EncodedPNG: String) {
-    let data = JupyterDisplay.MessageContent(base64EncodedPNG: base64EncodedPNG).json
+    let pngData = JupyterDisplay.PNGImageData(base64EncodedPNG: base64EncodedPNG)
+    let data = JupyterDisplay.MessageContent(data: pngData).json
     JupyterDisplay.messages.append(JupyterDisplay.Message(content: data))
 }


### PR DESCRIPTION
Hello everyone,

I have a proposal that allows people to have a simpler way of displaying messages with other mimetype than PNG.

The change allows the following example to work. Otherwise, it would be necessary to duplicate the entire `JupyterDisplay.MessageContent` struct and change the copy to work with HTML data:

```swift
%install '.package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0")' Cryptor
%include "EnableJupyterDisplay.swift"
```

```swift
struct HTMLData: Encodable {
    let html: String
    let text = "<IPython.core.display.HTML object>"
    private enum CodingKeys: String, CodingKey {
        case html = "text/html"
        case text = "text/plain"
    }
}

func display(html: String) {
    let htmlData = HTMLData(html: html)
    let data = JupyterDisplay.MessageContent(data: htmlData).json
    JupyterDisplay.messages.append(JupyterDisplay.Message(content: data))
}
```


The following cells can then output rich HTML representations:

```swift
let greenBox = "<div style='height: 100px; width: 100px; background-color: green'></div>"
display(html: greenBox)
```
![image](https://user-images.githubusercontent.com/8467740/73470395-70121f00-434d-11ea-9d45-72884464c097.png)


