### PR TITLE
disable completions by default because they are crashy

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -214,7 +214,9 @@ class SwiftKernel(Kernel):
         # SBTarget.CompleteCode API.
         # The user can disable/enable using "%disableCompletion" and
         # "%enableCompletion".
-        self.completion_enabled = hasattr(self.target, 'CompleteCode')
+        # TODO: Reenable completions when they become less crashy.
+        #self.completion_enabled = hasattr(self.target, 'CompleteCode')
+        self.completion_enabled = False
 
     def _init_repl_process(self):
         self.debugger = lldb.SBDebugger.Create()

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -203,6 +203,7 @@ class SwiftKernelTestsBase:
             if msg['msg_type'] == 'status':
                 break
 
+    @unittest.skip  # TODO: Reenable.
     def test_swift_completion(self):
         reply, output_msgs = self.execute_helper(code="""
             func aFunctionToComplete() {}


### PR DESCRIPTION
Temporarily disabling completions because they are crashy until we pull the https://bugs.swift.org/browse/SR-12076 fix into the s4tf toolchain.