### PR TITLE
switch notebook tests to master

### DIFF
--- a/test/tests/tutorial_notebook_tests.py
+++ b/test/tests/tutorial_notebook_tests.py
@@ -14,7 +14,7 @@ class TutorialNotebookTests(unittest.TestCase):
     def setUpClass(cls):
         cls.tmp_dir = tempfile.mkdtemp()
         git_url = 'https://github.com/tensorflow/swift.git'
-        os.system('git clone %s %s -b nightly-notebooks' % (git_url, cls.tmp_dir))
+        os.system('git clone %s %s -b master' % (git_url, cls.tmp_dir))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
With our new backwards-compatibility rules, the nightly toolchains should always be able to run the notebooks on github.com/tensorflow/swift:master, so let's switch the test to test against master!