### PR TITLE
import PythonKit or Python

### DIFF
--- a/EnableIPythonDisplay.swift
+++ b/EnableIPythonDisplay.swift
@@ -15,7 +15,11 @@
 /// Hooks IPython to the KernelCommunicator, so that it can send display
 /// messages to Jupyter.
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 enum IPythonDisplay {
   static var socket: PythonObject = Python.None


### PR DESCRIPTION
Import PythonKit or Python depending on which one is available, to support the Python => PythonKit transition.