### PR TITLE
work around TF-1179 by pointing at system libuuid

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -708,7 +708,7 @@ class SwiftKernel(Kernel):
             [swift_package_path, 'show-dependencies', '--format', 'json'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=package_base_path,
-            swiftpm_env=env)
+            env=swiftpm_env)
         dependencies_json = dependencies_result.stdout.decode('utf8')
         dependencies_obj = json.loads(dependencies_json)
 


### PR DESCRIPTION
**Problem**

When you install swift & swift-jupyer using jeremy's harebrained installation instructions (https://forums.fast.ai/t/jeremys-harebrained-install-guide/43814), conda gives you a bunch of shared libraries with versions slightly different from the ones that our swift nightlies and releases are built against. This is normally mostly fine -- you get some harmless warnings about "anaconda3/lib/xxx: no version information available".

However, swiftpm has recently added some logic that runs swiftc in a subprocess and reads the output as json. (https://github.com/apple/swift-package-manager/blob/0faa43fd9094ca905a3e666d040e7e0e36982fd6/Sources/Build/Triple.swift#L141) These warnings make the output be invalid json, so swiftpm dies!

**Workaround in this PR**

We can use LD_PRELOAD to make swift-build see the system libuuid, so that the warning does not appear, and the json gets parsed correctly.

Proper solution tracked in https://bugs.swift.org/browse/TF-1179.