### PR TITLE
Windows Implementation and Support

### DIFF
--- a/register.py
+++ b/register.py
@@ -66,7 +66,6 @@ def make_kernel_env(args):
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/macosx' % args.swift_toolchain
             kernel_env['REPL_SWIFT_PATH'] = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/repl_swift' % args.swift_toolchain
         elif platform.system() == 'Windows':
-            # kernel_env['PYTHONPATH'] = os.path.join(os.path.dirname(args.swift_toolchain),'Platforms','Windows.platform','Developer','SDKS','Windows.sdk','usr','lib','swift','windows')
             kernel_env['PYTHONPATH'] = os.environ['LLVM_PYTHON']
             kernel_env['LD_LIBRARY_PATH'] = os.path.join(os.path.dirname(os.path.dirname(args.swift_toolchain)),
                                                         'Platforms','Windows.platform','Developer','Library','XCTest-development',
@@ -172,30 +171,17 @@ def main():
     validate_kernel_env(kernel_env)
 
     script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
-    if platform.system() != 'Windows':
-        kernel_json = {
-            'argv': [
-                sys.executable,
-                '%s/parent_kernel.py' % script_dir,
-                '-f',
-                '{connection_file}',
-            ],
-            'display_name': args.kernel_name,
-            'language': 'swift',
-            'env': kernel_env,
-        }
-    else: # Slash orientation, os.path.join should work on other platforms though
-        kernel_json = {
-            'argv': [
-                sys.executable,
-                os.path.join(script_dir,'parent_kernel.py'),
-                '-f',
-                '{connection_file}',
-            ],
-            'display_name': args.kernel_name,
-            'language': 'swift',
-            'env': kernel_env,
-        }
+    kernel_json = {
+        'argv': [
+            sys.executable,
+            os.path.join(script_dir,'parent_kernel.py'),
+            '-f',
+            '{connection_file}',
+        ],
+        'display_name': args.kernel_name,
+        'language': 'swift',
+        'env': kernel_env,
+    }
     
     print('kernel.json:\n%s\n' % json.dumps(kernel_json, indent=2))
 

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -1064,7 +1064,8 @@ if __name__ == '__main__':
     # Jupyter sends us SIGINT when the user requests execution interruption.
     # Here, we block all threads from receiving the SIGINT, so that we can
     # handle it in a specific handler thread.
-    signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
+    if hasattr(signal, 'pthread_sigmask'): # Not supported in Windows
+        signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
 
     from ipykernel.kernelapp import IPKernelApp
     # We pass the kernel name as a command-line arg, since Jupyter gives those


### PR DESCRIPTION
The following changes should allow successful registration of the swift kernel in Windows, but isn't (yet) a functional jupyter kernel (see below - TODO).
Recently, there was a PR that added [installation instructions for Windows](https://github.com/tensorflow/swift/pull/411) in the [Tensorflow/swift repo](https://github.com/tensorflow/swift/blob/master/Installation.md).

Changes:
- Added conda support for MacOS and Windows
- Use `os.path` instead of hardcode slash 

Test:
- Conda env (using same instructions for conda)
- Toolchain: Windows pre-built March 6, 2020 (Development snapshots)

Additional Instructions:
- Assign environmental variable `LLVM_PYTHON` to installation directory ie: `C:\Program Files\LLVM\lib\site-packages`
  - This value is for `kernel_env['PYTHONPATH']`

Notes:
- In `swift_kernel.py`, Windows doesn't have the module `pthread_sigmask` in `signal`.
- Although the Windows toolchain said that lldb is included, I can't find the folder with lldb and its modules, just executables from usr/bin. This is why I did my first test run with the lldb contained in the [LLVM release](https://llvm.org/docs/index.html).

TODO:
- Running cells trigger an `AttributeError: type object 'object' has no attribute '__getattr__'` 
This comes from [L263 in swift_kernel.py](https://github.com/google/swift-jupyter/blob/master/swift_kernel.py#L263) `self.expr_opts.SetREPLMode(True)`. Earlier, I pointed the PYTHONPATH to an [LLVM Release](https://llvm.org/docs/index.html), and looking at its `__init__.py`, in the class `SBExpressionOptions` there is no function called `SetREPLMode`.
- Comparing to the lldb's `__init__.py` in a Ubuntu Nightly Release (`usr/lib/python3/dist-packages/lldb`), SBExpressionOptions has a few functions (including `SetREPLMode`) that the precompiled LLVM release does not have. Finalizing this step should make this work.

I'm not familiar with swig to compile a functional lldb for this, since both `__init__.py` and `_lldb.pyd` need to be generated. There's an [input file for swig here from llvm-mirror](https://github.com/llvm-mirror/lldb/blob/master/scripts/lldb.swig) if that helps anyone who wants to try this. 

I'll update this PR if there's any progress, and it should be worth implementing now that there's a [toolchain for Windows](https://github.com/tensorflow/swift/blob/master/Installation.md#windows) that "includes a copy of the compiler, lldb, and other related tools needed to provide a cohesive development experience for working in a specific version of Swift".