### PR TITLE
Fix paths for Windows

### DIFF
--- a/register.py
+++ b/register.py
@@ -66,11 +66,11 @@ def make_kernel_env(args):
             kernel_env['LD_LIBRARY_PATH'] = '%s/usr/lib/swift/macosx' % args.swift_toolchain
             kernel_env['REPL_SWIFT_PATH'] = '%s/System/Library/PrivateFrameworks/LLDB.framework/Resources/repl_swift' % args.swift_toolchain
         elif platform.system() == 'Windows':
-            kernel_env['PYTHONPATH'] = os.environ['LLVM_PYTHON']
+            kernel_env['PYTHONPATH'] = os.path.join('%s','usr','lib','site-packages') % args.swift_toolchain
             kernel_env['LD_LIBRARY_PATH'] = os.path.join(os.path.dirname(os.path.dirname(args.swift_toolchain)),
                                                         'Platforms','Windows.platform','Developer','Library','XCTest-development',
                                                         'usr','lib','swift')
-            kernel_env['REPL_SWIFT_PATH'] = '%s/usr/bin/repl_swift.exe' % args.swift_toolchain
+            kernel_env['REPL_SWIFT_PATH'] = os.path.join('%s','usr','bin','repl_swift.exe') % args.swift_toolchain
             
         else:
             raise Exception('Unknown system %s' % platform.system())


### PR DESCRIPTION
The updated swift-build by @compnerd has [updated lldb python bindings](https://github.com/compnerd/swift-build/pull/191). Thank you @compnerd for completing the quick feature request. The updated `PYTHONPATH` now points to `path/to/toolchain/usr/lib/site-packages` which contains the lldb module.

This PR also fixes the REPL path. After running `register.py` all the paths appear correct now.

I'll open an issue for this work-in-progress, and if possible I'd like to ask others to try testing this as well. Some TODO:
- [ ] Update Documentation for Windows instruction 
  - Users will have to follow the [TensorFlow/swift repo Windows Instructions](https://github.com/tensorflow/swift/blob/master/Installation.md#windows), and we will need to update the toolchain that has lldb, unless we add [Nightly installation instructions from compnerd/swift-build repo](https://github.com/compnerd/swift-build/blob/master/docs/Windows.md#downloading-the-nightlies).
- [ ] Successful kernel initialization (need testing)
  - After creating a notebook, running the kernel gives me an `ImportError: DLL load failed.` during `_lldb.pyd` import #98. 
- [ ] IDE Support
  - There are some who prefer to use PyCharm/VS Code/Atom/Nteract to run their Jupyter Notebook, although it's likely that this will work once the kernel initializes and REPL is functional.

