### PR TITLE
Create kernel gateway Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
-.git
-venv
+.dockerignore
+
+.idea/
+.git**
+screenshots/
+venv/
+
 **/*.pyc

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ jupyter notebook
 
 You should be able to create Swift notebooks. Installation is done!
 
-## Option 3: Using the Docker Container
+## Option 3: Using Docker to run Jupyter Notebook in a container
 
 This repository also includes a dockerfile which can be used to run a Jupyter Notebook instance which includes this Swift kernel. To build the container, the following command may be used:
 
@@ -123,6 +123,34 @@ To improve Docker image building, use the new [Docker Buildkit system](https://d
 
 ```bash
 DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t swift-jupyter .
+```
+
+## Option 4: Using Docker to run a Swift kernel connected to your local Jupyter Notebook
+
+As of Jupyter Notebook 6.0, you can use `--gateway-url=` to specify a separate [Jupyter Kernel Gateway](https://github.com/jupyter/kernel_gateway). (Or use the [nb2kg](https://github.com/jupyter/nb2kg) server extension for pre-6.0 versions of Notebook.) This allows running the Swift for Tensorflow Jupyter kernel in a Docker container while running Jupyter Notebook somewhere else, such as your local machine.
+
+First build the basic Swift kernel Docker image (as above), then build the kernel gateway image based on that:
+
+```bash
+# from inside the directory of this repository
+docker build -f docker/Dockerfile -t swift-jupyter .
+docker build -f kernel_gateway/Dockerfile -t swift-kg .
+```
+
+Using the new [Docker Buildkit system](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds) is recommended, as described in [the section above](#option-3-using-docker-to-run-jupyter-notebook-with-swift-for-tensorflow).
+
+Then run the kernel gateway:
+
+```bash
+docker run -p 9999:9999 --cap-add SYS_PTRACE swift-kg
+```
+
+The functions of these parameters are the same as in the section above.
+
+With the gateway running, start Jupyter Notebook in your notebook directory and pass the URL of your kernel gateway:
+
+```bash
+jupyter notebook --gateway-url 127.0.0.1:9999
 ```
 
 ## (optional) Building toolchain with LLDB Python3 support

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The functions of these parameters are:
 
 - `-v <host path>:/notebooks` bind mounts a host directory as a volume where notebooks created in the container will be stored.  If this command is omitted, any notebooks created using the container will not be persisted when the container is stopped.
 
+To improve Docker image building, use the new [Docker Buildkit system](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds) by either setting the `DOCKER_BUILDKIT` environment variable or configuring the Docker `daemon.json`. The simplest way is by prepending `DOCKER_BUILDKIT=1` to your `docker build` command:
+
+```bash
+DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t swift-jupyter .
+```
+
 ## (optional) Building toolchain with LLDB Python3 support
 
 Follow the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
-FROM gcr.io/swift-tensorflow/base-deps-cuda10.2-cudnn7-ubuntu18.04 
+# Start from S4TF base image
+FROM gcr.io/swift-tensorflow/base-deps-cuda10.2-cudnn7-ubuntu18.04
 
-# Allows the caller to specify the toolchain to use.
+# Allow the caller to specify the toolchain to use
 ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz
 
 # Upgrade pips
@@ -40,8 +41,10 @@ RUN echo "/usr/local/cuda-10.0/targets/x86_64-linux/lib/stubs" > /etc/ld.so.conf
 # Add Swift to the PATH
 ENV PATH="$PATH:/swift-tensorflow-toolchain/usr/bin/"
 
-# Run jupyter on startup
-EXPOSE 8888
+# Create the notebooks dir for mounting
 RUN mkdir /notebooks
 WORKDIR /notebooks
+
+# Run Jupyter on container start
+EXPOSE 8888
 CMD ["/swift-jupyter/docker/run_jupyter.sh", "--allow-root", "--no-browser", "--ip=0.0.0.0", "--port=8888", "--NotebookApp.custom_display_url=http://127.0.0.1:8888"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,19 +4,17 @@ FROM gcr.io/swift-tensorflow/base-deps-cuda10.2-cudnn7-ubuntu18.04
 # Allow the caller to specify the toolchain to use
 ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz
 
-# Upgrade pips
-RUN pip2 install --upgrade pip
-RUN pip3 install --upgrade pip
-
-# Install swift-jupyter's dependencies in python3 because we run the kernel in python3.
+# Install some python libraries that are useful to call from swift
+# Since swift can interoperate with python2 and python3, install them in both
+# Install swift-jupyter's dependencies in python3 because we run the kernel in python3
 WORKDIR /swift-jupyter
 COPY docker/requirements*.txt ./
-RUN pip3 install -r requirements.txt
-
-# Install some python libraries that are useful to call from swift. Since
-# swift can interoperate with python2 and python3, install them in both.
-RUN pip2 install -r requirements_py_graphics.txt
-RUN pip3 install -r requirements_py_graphics.txt
+RUN python2 -m pip install --upgrade pip \
+    && python2 -m pip install --no-cache-dir -r requirements.txt \
+    && python2 -m pip install --no-cache-dir -r requirements_py_graphics.txt
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --no-cache-dir -r requirements.txt \
+    && python3 -m pip install --no-cache-dir -r requirements_py_graphics.txt
 
 # Copy the kernel into the container
 WORKDIR /swift-jupyter

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,10 +16,6 @@ RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --no-cache-dir -r requirements.txt \
     && python3 -m pip install --no-cache-dir -r requirements_py_graphics.txt
 
-# Copy the kernel into the container
-WORKDIR /swift-jupyter
-COPY . .
-
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
 ADD $swift_tf_url swift.tar.gz
@@ -27,8 +23,11 @@ RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz
 
-# Register the kernel with jupyter
+# Copy the kernel into the container
 WORKDIR /swift-jupyter
+COPY . .
+
+# Register the kernel with jupyter
 RUN python3 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-version 2.7 --kernel-name "Swift (with Python 2.7)" && \
     python3 register.py --user --swift-toolchain /swift-tensorflow-toolchain --swift-python-library /usr/lib/x86_64-linux-gnu/libpython3.6m.so --kernel-name "Swift"
 

--- a/kernel_gateway/Dockerfile
+++ b/kernel_gateway/Dockerfile
@@ -1,0 +1,12 @@
+# Start from swift-jupyter image
+FROM swift-jupyter:latest
+
+# Install the kernel gateway.
+WORKDIR /swift-jupyter
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install jupyter_kernel_gateway
+
+# Run the kernel gateway on container start, with overrideable args
+EXPOSE 9999
+ENTRYPOINT ["python3", "-m", "jupyter", "kernelgateway"]
+CMD ["--ip=0.0.0.0", "--port=9999"]


### PR DESCRIPTION
I've been wanting a way to run the Swift kernel locally, but using my own Jupyter instance not in a Docker container. So I created a descendent Dockerfile that adds Jupyter Kernel Gateway to the swift-jupyter image and runs it on container startup. Details are in [the readme](https://github.com/cboone/google-swift-jupyter/blob/dbc3ea74cad13b927e97b8b53980ea2fc27a6712/README.md).

This seems like a big improvement in terms of local S4TF workflow, though there are definitely other ways this could be handled. (Two that come to mind: a separate project for the kernel gateway Dockerfile; or including kernelgateway in the regular image but allowing for runtime choice of notebook or kernelgateway.)

I also did some tidy up of the Dockerfile (to reduce cache busting and reduce number of image layers), added some files to .dockerignore (to reduce image size, albeit inconsequentially), and made a recommendation to use Docker Buildkit (to improve the building process). Those all seem good and relevant to me, but aren't necessary to creating the kernelgateway image.

Let me know how this looks. Thanks!