### PR TITLE
disable showing expression values

### DIFF
--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -14,7 +14,7 @@ class SwiftKernelTests(jupyter_kernel_test.KernelTests):
     code_hello_world = 'print("hello, world!")'
 
     code_execute_result = [
-        {'code': 'let x = 2; x', 'result': '2\n'}
+        {'code': 'let x = 2; x', 'result': 'Use `print()` to show values.\n'},
     ]
 
     code_generate_error = 'varThatIsntDefined'
@@ -264,6 +264,16 @@ class SwiftKernelTests(jupyter_kernel_test.KernelTests):
                     'text': '\r\nafter the clear\r\n',
                 },
             })
+
+    def test_show_tensor(self):
+        reply, output_msgs = self.execute_helper(code="""
+           import TensorFlow
+           Tensor([1, 2, 3])
+        """)
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertIn(
+                "Use `print()` to show values",
+                output_msgs[0]['content']['data']['text/plain'])
 
 
 # Class for tests that need their own kernel. (`SwiftKernelTestsBase` uses one

--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -271,9 +271,10 @@ class SwiftKernelTests(jupyter_kernel_test.KernelTests):
            Tensor([1, 2, 3])
         """)
         self.assertEqual(reply['content']['status'], 'ok')
-        self.assertIn(
-                "Use `print()` to show values",
-                output_msgs[0]['content']['data']['text/plain'])
+        if 'data' in output_msgs[0]['content']:
+            self.assertIn(
+                    "Use `print()` to show values",
+                    output_msgs[0]['content']['data']['text/plain'])
 
 
 # Class for tests that need their own kernel. (`SwiftKernelTestsBase` uses one


### PR DESCRIPTION
The recent merge causes LLDB to crash when it tries to show an expression value (with `result.description`).

This PR replaces all uses of `result.description` with a few different non-crashing alternatives:
* When we know the type, of the value, use `GetSignedInt32()`.
* When `GetDescription()` works, use that.
* In a case where even `GetDescription()` crashes, print a message telling the user that they can show the value using `print()`. I made https://github.com/google/swift-jupyter/issues/112 to track fixing this.