### PR TITLE
make swift-jupyter work without extra privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ The resulting container comes with the latest Swift for TensorFlow toolchain ins
 This container can now be run with the following command:
 
 ```bash
-docker run -p 8888:8888 --privileged -v /my/host/notebooks:/notebooks swift-jupyter
+docker run -p 8888:8888 --cap-add SYS_PTRACE -v /my/host/notebooks:/notebooks swift-jupyter
 ```
 
 The functions of these parameters are:
 
 - `-p 8888:8888` exposes the port on which Jupyter is running to the host.
 
-- `--privileged` adjusts the privileges with which this container is run, which is required for the Swift REPL. (We would like to reduce the required privileges: https://github.com/google/swift-jupyter/issues/116).
+- `--cap-add SYS_PTRACE` adjusts the privileges with which this container is run, which is required for the Swift REPL.
 
 - `-v <host path>:/notebooks` bind mounts a host directory as a volume where notebooks created in the container will be stored.  If this command is omitted, any notebooks created using the container will not be persisted when the container is stopped.
 
@@ -144,7 +144,7 @@ Using the new [Docker Buildkit system](https://docs.docker.com/develop/develop-i
 Then run the kernel gateway:
 
 ```bash
-docker run -p 9999:9999 --privileged swift-kg
+docker run -p 9999:9999 --cap-add SYS_PTRACE swift-kg
 ```
 
 The functions of these parameters are the same as in the section above.
@@ -379,5 +379,5 @@ python test/notebook_tester.py --help
 After building the docker image according to the instructions above,
 
 ```
-docker run --privileged swift-jupyter python3 /swift-jupyter/test/all_test_docker.py
+docker run --cap-add SYS_PTRACE swift-jupyter python3 /swift-jupyter/test/all_test_docker.py
 ```

--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -257,6 +257,13 @@ class SwiftKernel(Kernel):
                 continue
             repl_env.append('%s=%s' % (key, os.environ[key]))
 
+        # Turn off "disable ASLR" because it uses the "personality" syscall in
+        # a way that is forbidden by the default Docker security policy.
+        launch_info = self.target.GetLaunchInfo()
+        launch_flags = launch_info.GetLaunchFlags()
+        launch_info.SetLaunchFlags(launch_flags & ~lldb.eLaunchFlagDisableASLR)
+        self.target.SetLaunchInfo(launch_info)
+
         self.process = self.target.LaunchSimple(None,
                                                 repl_env,
                                                 os.getcwd())


### PR DESCRIPTION
"Disable ASLR" uses the "personality" syscall in a way that is forbidden by the default Docker security policy. This PR turns of "disable ASLR" so that swift-jupyter works with the default policy.

This used to not be a problem. I guess that someone recently make "disable ASLR" the default somewhere, causing it to start being a problem.

Fixes #116.