### PR TITLE
fix error message conformance to jupyter spec

### DIFF
--- a/swift_kernel.py
+++ b/swift_kernel.py
@@ -921,8 +921,6 @@ class SwiftKernel(Kernel):
 
     def _make_error_message(self, traceback):
         return {
-            'status': 'error',
-            'execution_count': self.execution_count,
             'ename': '',
             'evalue': '',
             'traceback': traceback


### PR DESCRIPTION
According to the spec, the "execution_count" and "status" should be omitted from error messages: https://jupyter-client.readthedocs.io/en/stable/messaging.html#execution-errors .