### PR TITLE
Support load from Bazel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM gcr.io/swift-tensorflow/base-deps-cuda10.2-cudnn7-ubuntu18.04
 # Allow the caller to specify the toolchain to use
 ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz
 
+RUN apt install curl gnupg
+RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/bazel.gpg
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN apt-get update \
+  && apt-get install -y bazel
+
 # Install some python libraries that are useful to call from swift
 WORKDIR /swift-jupyter
 COPY docker/requirements*.txt ./
@@ -31,6 +37,10 @@ ENV PATH="$PATH:/swift-tensorflow-toolchain/usr/bin/"
 # Create the notebooks dir for mounting
 RUN mkdir /notebooks
 WORKDIR /notebooks
+
+COPY docker/WORKSPACE .
+COPY docker/PythonKit.BUILD external/
+COPY docker/.bazelrc .
 
 # Run Jupyter on container start
 EXPOSE 8888

--- a/docker/.bazelrc
+++ b/docker/.bazelrc
@@ -1,0 +1,7 @@
+build:clang --action_env=CC=clang
+build:clang --action_env=CXX=clang++
+build:clang --linkopt='-L/usr/local/lib'
+build:clang --linkopt='-Wl,-rpath,/usr/local/lib'
+
+build --config=clang
+

--- a/docker/PythonKit.BUILD
+++ b/docker/PythonKit.BUILD
@@ -1,0 +1,13 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+	default_visibility = ["//visibility:public"],
+)
+
+swift_library(
+	name = "PythonKit",
+	module_name = "PythonKit",
+	srcs = glob([
+		"PythonKit/**/*.swift"
+	])
+)

--- a/docker/WORKSPACE
+++ b/docker/WORKSPACE
@@ -1,0 +1,28 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
+git_repository(
+	name = "build_bazel_rules_swift",
+	remote = "https://github.com/bazelbuild/rules_swift.git",
+	commit = "6ae82f57ebefa13df5ce1daf7a2fd3080e41df55",
+	shallow_since = "1599689969 -0700"
+)
+
+load("@build_bazel_rules_swift//swift:repositories.bzl", "swift_rules_dependencies")
+
+swift_rules_dependencies()
+
+load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+
+apple_support_dependencies()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+new_git_repository(
+	name = "PythonKit",
+	remote = "https://github.com/pvieito/PythonKit.git",
+	commit = "59a868e84e1d6a5e01569cf92086554033415fa4",
+	shallow_since = "1604702703 -0800",
+	build_file = "PythonKit.BUILD"
+)

--- a/whole_archive.bzl
+++ b/whole_archive.bzl
@@ -1,0 +1,103 @@
+# -*- python -*-
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+# Copyright 2019 Toyota Research Institute. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This function is forked and modified from bazelbuild/rules_cc as of:
+# https://github.com/bazelbuild/rules_cc/blob/262ebec3c2296296526740db4aefce68c80de7fa/cc/find_cc_toolchain.bzl
+def _find_cc_toolchain(ctx):
+    # Check the incompatible flag for toolchain resolution.
+    if hasattr(cc_common, "is_cc_toolchain_resolution_enabled_do_not_use") and cc_common.is_cc_toolchain_resolution_enabled_do_not_use(ctx = ctx):  # noqa
+        if "//cc:toolchain_type" in ctx.toolchains:
+            return ctx.toolchains["//cc:toolchain_type"]
+        fail("In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.")  # noqa
+
+    # Fall back to the legacy implicit attribute lookup.
+    if hasattr(ctx.attr, "_cc_toolchain"):
+        return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+
+    # We didn't find anything.
+    fail("In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.")  # noqa
+
+# This function is forked and modified from bazelbuild/rules_cc as of:
+# https://github.com/bazelbuild/rules_cc/blob/262ebec3c2296296526740db4aefce68c80de7fa/examples/my_c_archive/my_c_archive.bzl
+def _cc_whole_archive_library_impl(ctx):
+    # Find the C++ toolchain.
+    cc_toolchain = _find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    # Iterate over the transitive list of libraries we want to link, adding
+    # `alwayslink = True` to each one.
+    deps_cc_infos = cc_common.merge_cc_infos(
+        cc_infos = [dep[CcInfo] for dep in ctx.attr.deps],
+    )
+    old_libraries_to_link = deps_cc_infos.linking_context.libraries_to_link.to_list()  # noqa
+    new_libraries_to_link = []
+    for old_library_to_link in old_libraries_to_link:
+        new_library_to_link = cc_common.create_library_to_link(
+            actions = ctx.actions,
+            feature_configuration = feature_configuration,
+            cc_toolchain = cc_toolchain,
+            static_library = old_library_to_link.static_library,
+            pic_static_library = old_library_to_link.pic_static_library,
+            dynamic_library = old_library_to_link.resolved_symlink_dynamic_library,  # noqa
+            interface_library = old_library_to_link.resolved_symlink_interface_library,  # noqa
+            # This is where the magic happens!
+            alwayslink = True,
+        )
+        new_libraries_to_link.append(new_library_to_link)
+
+    # Return the CcInfo to pass along to code that wants to link us.
+    linking_context = cc_common.create_linking_context(
+        libraries_to_link = new_libraries_to_link,
+        user_link_flags = deps_cc_infos.linking_context.user_link_flags,
+        additional_inputs = deps_cc_infos.linking_context.additional_inputs.to_list(),  # noqa
+    )
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+            ),
+        ),
+        CcInfo(
+            compilation_context = deps_cc_infos.compilation_context,
+            linking_context = linking_context,
+        ),
+    ]
+
+# Forked and modified from bazelbuild/rules_cc as of:
+# https://github.com/bazelbuild/rules_cc/blob/262ebec3c2296296526740db4aefce68c80de7fa/examples/my_c_archive/my_c_archive.bzl
+cc_whole_archive_library = rule(
+    implementation = _cc_whole_archive_library_impl,
+    attrs = {
+        "deps": attr.label_list(providers = [CcInfo]),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)
+"""Creates an cc_library with `alwayslink = True` added to all of its deps, to
+work around https://github.com/bazelbuild/bazel/issues/7362 not providing any
+useful way to create shared libraries from multiple cc_library targets unless
+you want even statically-linked programs to keep all of their symbols.
+"""


### PR DESCRIPTION
This added support to load Swift libraries from a Bazel-based monorepo.
It makes assumption that Jupyter is launched from within that monorepo.

How to:

```
%bazel "@PythonKit//:PythonKit"
```

This will install Bazel packages available locally, and made them
available for the notebook to use.

There is a more detailed discussion of steps we do to achieve this.

---

I am not sure if this fits to upstream, since it is substantial of work and
many in the Swift community may not use Bazel as their build tools.
nevertheless, putting this up to receive comments. I am OK with not
upstreaming this, or other suggestions (like modularize the shared parts
between Bazel / SwiftPM, and upstreaming these refactorings while keeping
Bazel portion to myself etc).