### PR TITLE
fix test for new ipykernel version

### DIFF
--- a/test/tests/kernel_tests.py
+++ b/test/tests/kernel_tests.py
@@ -154,6 +154,8 @@ class SwiftKernelTests(jupyter_kernel_test.KernelTests):
                 self.assertEqual(msg['content']['execution_state'], 'idle')
                 break
 
+        self.flush_channels()
+
         # Check that the kernel can still execute things after handling an
         # interrupt.
         reply, output_msgs = self.execute_helper(


### PR DESCRIPTION
ipykernel-5.3.4 changed to ipykernel-5.4.0, and this test stopped working.

`flush_channels()` seems to fix it.

I don't thoroughly understand what is going on, but my guess is: the new version of ipykernel sends more messages for some reason, the test doesn't consume all of the messages before trying to execute new code, and therefore `self.execute_helper` interprets some of the old messages as replies to the new code execution and gets confused. So `flush_channels()` clears out those old messages.